### PR TITLE
Context debug verbose setup

### DIFF
--- a/beaker-vue/src/components/BeakerCodecell.vue
+++ b/beaker-vue/src/components/BeakerCodecell.vue
@@ -6,7 +6,7 @@
         <Codemirror
             v-model="cell.source"
             placeholder="Your code..."
-            :extensions="extensions"
+            :extensions="codeExtensions"
             :disabled="isBusy"
             @keydown.ctrl.enter.self.stop.prevent="execute"
             @keydown.alt.enter="console.log('alt-enter')"
@@ -29,13 +29,13 @@ const props = defineProps([
     "cell",
     "session",
     "contextData",
-    "selectedTheme"
+    "theme"
 ]);
 
 const cell = ref(props.cell);
 const isBusy = ref(false);
 
-const extensions = computed(() => {
+const codeExtensions = computed(() => {
     const ext = [];
 
     const subkernel = props?.contextData?.language?.subkernel || '';
@@ -43,7 +43,7 @@ const extensions = computed(() => {
     if (isPython) {
         ext.push(python());
     }
-    if (props.selectedTheme === 'dark') {
+    if (props.theme === 'dark') {
         ext.push(oneDark);
     }
     return ext;

--- a/beaker-vue/src/components/BeakerCodecellOutput.vue
+++ b/beaker-vue/src/components/BeakerCodecellOutput.vue
@@ -64,6 +64,7 @@ const renderResult = (resultOutput) => {
     font-weight: bold;
     position: absolute;
     top: 0.5rem;
+    right: 0.25rem;
 }
 
 

--- a/beaker-vue/src/components/BeakerCodecellOutput.vue
+++ b/beaker-vue/src/components/BeakerCodecellOutput.vue
@@ -1,8 +1,9 @@
 <template>
     <div class="code-cell-output">
-        <div v-if="busy">
-            <i class="pi pi-spin pi-spinner spinner" />
-        </div>
+        <i
+            v-if="busy"
+            class="pi pi-spin pi-spinner busy-icon"
+        />
         <div v-for="output of props.outputs" :key="output">
             <div v-if="output.output_type == 'stream'" :class="output.name">{{ output.text }}</div>
             <div v-else-if="output.output_type == 'display_data'" :class="output.name" v-html="renderResult(output)"></div>
@@ -59,13 +60,13 @@ const renderResult = (resultOutput) => {
     white-space: pre;
 }
 
-.spinner {
+.busy-icon {
     color: var(--blue-500);
     font-weight: bold;
+    font-size: 1.2rem;
     position: absolute;
-    top: 0.5rem;
-    right: 0.25rem;
+    top: 0.4rem;
+    right: 1.2rem;
 }
-
 
 </style>

--- a/beaker-vue/src/components/BeakerCustomMessage.vue
+++ b/beaker-vue/src/components/BeakerCustomMessage.vue
@@ -6,6 +6,7 @@
         <div class="code">
             <Codemirror
                 :tab-size="2"
+                :extensions="codeExtensions"
                 language="javascript"
                 v-model="messageContent"
             />
@@ -32,8 +33,9 @@
 </template>
 
 <script setup lang="ts">
-import { defineProps, defineEmits, ref } from "vue";
+import { defineProps, defineEmits, ref, computed } from "vue";
 import { Codemirror } from "vue-codemirror";
+import { oneDark } from '@codemirror/theme-one-dark';
 import Button from 'primevue/button';
 import InputText from 'primevue/inputtext';
 import InputGroup from 'primevue/inputgroup';
@@ -43,6 +45,7 @@ import Fieldset from 'primevue/fieldset';
 const props = defineProps([
     "session",
     "expanded",
+    "theme"
 ]);
 
 // const query = ref("");
@@ -51,6 +54,16 @@ const emit = defineEmits([
     "run-cell",
     "update-context-info",
 ]);
+
+const codeExtensions = computed(() => {
+    const ext = [];
+
+    if (props.theme === 'dark') {
+        ext.push(oneDark);
+    }
+    return ext;
+
+});
 
 const messageType = ref<string>();
 const messageContent = ref<string>("{\n}");

--- a/beaker-vue/src/components/BeakerLLMQueryCell.vue
+++ b/beaker-vue/src/components/BeakerLLMQueryCell.vue
@@ -10,14 +10,14 @@
                         v-model="editingContents"
                     />
                     <div class="edit-actions">
-                        <Button outlined label="Save" size="small" @click="saveEdit"/>
-                        <Button outlined severity="danger" @click="cancelEdit" label="Cancel" size="small" />
+                        <Button outlined class="save-button" label="Save" size="small" @click="saveEdit"/>
+                        <Button outlined class="cancel-button" @click="cancelEdit" label="Cancel" size="small" />
                     </div>
                 </div>
                 <div v-else>
-                    <span v-if="savedEdit">
-                        {{savedEdit}}
-                    </span>
+                    <p v-if="savedEdit" style="margin: 0; padding: 0;">
+                        {{savedEdit}} <span style="font-weight: 100;">(edited)</span>
+                    </p>
                     <span v-else>
                         {{ cell.source }}
                     </span>
@@ -153,5 +153,14 @@ const busy = computed(() => {
     }
 }
 
+.save-button {
+    border-color: var(--surface-200);
+    color: var(--primary-text-color);
+}
+
+.cancel-button {
+    border-color: var(--surface-100);
+    color: var(--primary-text-color);
+}
 
 </style>

--- a/beaker-vue/src/components/BeakerLLMQueryCell.vue
+++ b/beaker-vue/src/components/BeakerLLMQueryCell.vue
@@ -4,8 +4,8 @@
             <div class="query">{{ cell.source }}</div>
             <div v-if="busy">
                 <i
-                    class="pi pi-spin pi-cog"
-                    style="color: var(--yellow-500); font-weight: bold;"
+                    class="pi pi-spin pi-spinner"
+                    style="color: var(--blue-500); font-weight: bold;"
                 />
             </div>
             <div v-else>

--- a/beaker-vue/src/components/BeakerLLMQueryCell.vue
+++ b/beaker-vue/src/components/BeakerLLMQueryCell.vue
@@ -1,17 +1,51 @@
 <template>
     <div class="llm-query-cell">
-        <div style="display: flex; justify-content: space-between">
-            <div class="query">{{ cell.source }}</div>
-            <div v-if="busy">
-                <i
-                    class="pi pi-spin pi-spinner"
-                    style="color: var(--blue-500); font-weight: bold;"
-                />
+        <div class="query-row">
+            <div class="query">
+                <div v-if="editing" style="display: flex">
+                    <InputText
+                        type="text"
+                        size="small"
+                        ref="autofocus"
+                        v-model="editingContents"
+                    />
+                    <div class="edit-actions">
+                        <Button outlined label="Save" size="small" @click="saveEdit"/>
+                        <Button outlined severity="danger" @click="cancelEdit" label="Cancel" size="small" />
+                    </div>
+                </div>
+                <div v-else>
+                    <span v-if="savedEdit">
+                        {{savedEdit}}
+                    </span>
+                    <span v-else>
+                        {{ cell.source }}
+                    </span>
+                </div>
             </div>
-            <div v-else>
-                <i
-                    class="pi pi-check-circle"
-                    style="color: var(--green-500); font-weight: bold;"
+            <div class="actions">
+                <Button
+                    text
+                    size="small"
+                    icon="pi pi-pencil"
+                    severity="info"
+                    @click="startEdit"
+                />
+                <Button
+                    v-if="busy"
+                    style="pointer-events: none;"
+                    text
+                    size="small"
+                    severity="info"
+                    icon="pi pi-spin pi-spinner"
+                />
+                <Button
+                    v-else
+                    style="pointer-events: none;"
+                    text
+                    size="small"
+                    severity="success"
+                    icon="pi pi-check-circle"
                 />
             </div>
         </div>
@@ -22,7 +56,11 @@
 </template>
 
 <script setup lang="ts">
-import { defineProps, ref, computed } from "vue";
+import { defineProps, ref, computed, nextTick } from "vue";
+import Button from "primevue/button"; 
+import InputText from 'primevue/inputtext';
+
+// TODO put actions in a card/container?
 
 const props = defineProps([
     "cell",
@@ -31,10 +69,37 @@ const props = defineProps([
 
 const cell = ref(props.cell);
 const timeout = ref(false);
+const editing = ref(false);
+const editingContents = ref("");
+const autofocus = ref();
+const savedEdit = ref("");
+
 
 setTimeout(() => {
     timeout.value = true;
 }, 8000);
+
+function cancelEdit() {
+    editing.value = false;
+    editingContents.value = savedEdit.value || cell.value.source;
+}
+
+async function startEdit() {
+    if (editing.value === true) {
+        await nextTick();
+        autofocus.value.$el.focus();
+        return;
+    }
+    editing.value = true;
+    editingContents.value = savedEdit.value || cell.value.source;
+    await nextTick();
+    autofocus.value.$el.focus();
+}
+
+function saveEdit() {
+    editing.value = false;
+    savedEdit.value = editingContents.value;
+}
 
 const busy = computed(() => {
     return props.cell.source &&
@@ -47,21 +112,46 @@ const busy = computed(() => {
 
 <style lang="scss">
 .llm-query-cell {
-    padding: 1em;
+    padding: 0.5rem 1.2rem 1rem 1.2rem;
+}
+
+.query-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
 }
 
 .query {
     font-weight: bold;
-    margin-bottom: 0.5em;
+    flex: 1;
+    line-height: 2.5rem;
+    margin-bottom: 0.5rem;
 }
 
 .thought {
-    color: var(--orange-400);
+    color: var(--blue-400);
 }
 
 .response {
     margin-top: 1em;
     white-space: pre-line;
 }
+
+.actions {
+    display: flex;
+    .p-button-icon {
+        font-weight: bold;
+        font-size: 1rem;
+    }
+}
+
+.edit-actions {
+    display: flex;
+    margin-left: 0.5rem;
+    .p-button {
+        margin-right: 0.5rem;
+    }
+}
+
 
 </style>

--- a/beaker-vue/src/components/BeakerNotebook.vue
+++ b/beaker-vue/src/components/BeakerNotebook.vue
@@ -65,7 +65,7 @@
 
         <main style="display: flex;">
 
-            <ContextTree />
+            <ContextTree :context="props.contextSetupData"/>
 
             <Splitter class="splitter">
 
@@ -116,7 +116,7 @@
                 >
                     <TabView :activeIndex="0">
                         <TabPanel header="Preview">
-                            <div style="scroller-area">
+                            <div class="scroller-area">
                                 <PreviewPane />
                             </div>
                         </TabPanel>
@@ -129,7 +129,8 @@
                                         <BeakerCustomMessage 
                                             :theme="selectedTheme"
                                             :session="session"
-                                            :expanded="true"/>
+                                            :expanded="true"
+                                        />
                                     </template>
                                 </Card>
                                 <Card>
@@ -204,7 +205,8 @@ const componentMap: {[key: string]: Component} = {
 
 const props = defineProps([
     "session",
-    "connectionStatus"
+    "connectionStatus",
+    "contextSetupData"
 ]);
 
 // TODO export/import from ts-lib utils.ts

--- a/beaker-vue/src/components/LoggingDrawer.vue
+++ b/beaker-vue/src/components/LoggingDrawer.vue
@@ -1,9 +1,9 @@
 <template>
 
-    <Menubar
-        :model="footerMenuItems"
-        breakpoint="800"
-     />
+  <Menubar
+      :model="footerMenuItems"
+      breakpoint="800"
+   />
 
   <transition name="slide">
     <div class="logging-pane" v-if="isLogOpen">

--- a/beaker-vue/src/components/PreviewPane.vue
+++ b/beaker-vue/src/components/PreviewPane.vue
@@ -1,5 +1,5 @@
 <template>
-  <Accordion multiple :activeIndex="[0]" style="height: 100%;">
+  <Accordion multiple :activeIndex="[0]">
       <AccordionTab header="Petri Net">
           <div class="mime-select-container">
               <SelectButton


### PR DESCRIPTION
There are a lot of changes here, so I'll merge and continue working on them:

- Add and send debug|verbose flags when setting up the context
- Don’t auto-open context dialog until user clicks on the context button
- Move code eval animation to same spot as agent processing animation; revisit agent load animation and thoughts colors
- Add edit prompt functionality to the agent query cell, with a text-input to edit and submit the changes. PENDING changing internal value so that agent reevaluates data shown as edited.
- Populate context tree with real data, by passing the context data from the appropriate msg to the tree view component (intercepts, subkernel (language), tools, procedures)
- Some misc fixes for errors/panel layout