### PR TITLE
Fixes the assigned class name for code cell outputs- before class attribute was empty. Formatted execute_result output types.

### DIFF
--- a/beaker-vue/src/components/BeakerCodecellOutput.vue
+++ b/beaker-vue/src/components/BeakerCodecellOutput.vue
@@ -5,10 +5,10 @@
             class="pi pi-spin pi-spinner busy-icon"
         />
         <div v-for="output of props.outputs" :key="output">
-            <div v-if="output.output_type == 'stream'" :class="output.name">{{ output.text }}</div>
-            <div v-else-if="output.output_type == 'display_data'" :class="output.name" v-html="renderResult(output)"></div>
-            <div v-else-if="output.output_type == 'execute_result'" :class="output.name" v-html="renderResult(output)"></div>
-            <div v-else-if="output.output_type == 'error'" :class="output.name" v-html="renderError(output)"></div>
+            <div v-if="output.output_type == 'stream'" :class="output.output_type">{{ output.text }}</div>
+            <div v-else-if="output.output_type == 'display_data'" :class="output.output_type" v-html="renderResult(output)"></div>
+            <div v-else-if="output.output_type == 'execute_result'" :class="output.output_type" v-html="renderResult(output)"></div>
+            <div v-else-if="output.output_type == 'error'" :class="output.output_type" v-html="renderError(output)"></div>
             <div v-else>{{ output }}</div>
         </div>
     </div>
@@ -59,6 +59,12 @@ const renderError = (errorOutput) => {
     background-color: var(--surface-c);
     position: relative;
     overflow-x: auto;
+    .execute_result {
+        pre {
+            white-space: break-spaces;
+            overflow-wrap: break-word;
+        }
+    }
 }
 
 .stdout {

--- a/beaker-vue/src/components/BeakerCodecellOutput.vue
+++ b/beaker-vue/src/components/BeakerCodecellOutput.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="code-cell-output">
+    <div class="code-cell-output jp-RenderedText">
         <i
             v-if="busy"
             class="pi pi-spin pi-spinner busy-icon"
@@ -52,7 +52,8 @@ const renderError = (errorOutput) => {
 
 <style lang="scss">
 @import url('@jupyterlab/notebook/style/index.css');
-// @import url('@jupyterlab/theme-light-extension/style/theme.css');
+@import url('@jupyterlab/outputarea/style/index.css');
+@import url('@jupyterlab/rendermime/style/index.css');
 
 .code-cell-output {
     padding: 1em;


### PR DESCRIPTION
Added a rule for words to wrap on code cell output of type `execute_result`; tested with python output. Did not address any other output types such as `print()` output for now.

How the execute_result (of a python var being evaluated) looks now:

<img width="1672" alt="Screenshot 2024-02-20 at 9 56 58 PM" src="https://github.com/jataware/beaker-kernel/assets/1967061/f6af81a9-59ad-4d84-824b-d909ca619ea6">

The classes attached to the code cell outputs from `output.output_type`:

<img width="514" alt="Screenshot 2024-02-20 at 9 58 41 PM" src="https://github.com/jataware/beaker-kernel/assets/1967061/133f8a42-3b95-4da2-b980-4a892f4f86d0">

(eg `execute_result`, `stream`).