### PR TITLE
Remove env variables that contain "KEY", "SECRET" or "TOKEN" from subkernels

### DIFF
--- a/beaker_kernel/server/dev.py
+++ b/beaker_kernel/server/dev.py
@@ -28,6 +28,7 @@ def _jupyter_server_extension_points():
 class DevBeakerJupyterApp(BeakerJupyterApp):
     pass
 
+
 class BeakerHandler(watchdog_events.FileSystemEventHandler):
     def __init__(self, observer, modules) -> None:
         super().__init__()


### PR DESCRIPTION
All keys still exist at the beaker kernel level, so secrets can be used, but cannot be fetched from subkernel/code cell level.

Probably still avenues to leak secrets via procedures, but this solves the immediate problem.

This is the cleanest solution I could come up with. I would have preferred to not copy/paste the whole `MainKernelHandler.post()` function, but there wasn't a more targeted way to do so that I could find.