### PR TITLE
Two minor tweaks

### DIFF
--- a/beaker_kernel/lib/context.py
+++ b/beaker_kernel/lib/context.py
@@ -190,23 +190,25 @@ class BaseContext:
         }
         return payload
 
+    async def get_subkernel_state(self):
+        fetch_state_code = self.subkernel.FETCH_STATE_CODE
+        state = await self.evaluate(fetch_state_code)
+        return state["return"]
 
-    @action()
-    async def get_subkernel_state(self, message):
+    @action(action_name="get_subkernel_state")
+    async def get_subkernel_state_action(self, message):
         """
         Fetches the state of the subkernel, including all defined variables, imports, and functions.
         """
-        fetch_state_code = self.subkernel.FETCH_STATE_CODE
-        state = await self.beaker_kernel.evaluate(fetch_state_code)
-        result = state["return"]
+        state = await self.get_subkernel_state()
         self.send_response(
             stream="iopub",
             msg_or_type="get_subkernel_state_response",
-            content=result,
+            content=state,
             parent_header=message.header,
         )
-        return result
-    get_subkernel_state._default_payload = "{}"
+        return state
+    get_subkernel_state_action._default_payload = "{}"
 
 
     @action()


### PR DESCRIPTION
1. Moved `get_subkernel_state` to be a regular method instead of just an action so we can use it directly in code without worrying about messages. Added message handing and action decorator to `get_subkernel_state_action`, but with an action name of `get_subkernel_state` so it does not affect existing code.

2. Added ability to pass extra dirs to watch when running beaker server in dev mode using the new --extra_watch_dir command line argument. Allows one to specify other code locations to watch for changes and will restart beaker if changes are found.