### PR TITLE
Bump version to v1.5.3

### DIFF
--- a/beaker_kernel/lib/agent.py
+++ b/beaker_kernel/lib/agent.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 class BaseAgent(ReActAgent):
 
     context: "BaseContext"
-    MODEL: str = "gpt-4o"
+    MODEL: str = "gpt-4-turbo-preview"
 
     def __init__(
         self,

--- a/beaker_kernel/lib/agent.py
+++ b/beaker_kernel/lib/agent.py
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
 class BaseAgent(ReActAgent):
 
     context: "BaseContext"
+    MODEL: str = "gpt-4o"
 
     def __init__(
         self,
@@ -30,7 +31,7 @@ class BaseAgent(ReActAgent):
             "verbose": self.context.beaker_kernel.verbose,
         })
         super().__init__(
-            model="gpt-4-turbo-preview",  # Use default
+            model=self.MODEL,  # Use default
             # api_key=api_key,  # TODO: get this from configuration
             tools=tools,
             verbose=self.context.beaker_kernel.verbose,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "matplotlib~=3.7.1",
   "xarray==0.19.0",
   "numpy~=1.24.3",
-  "archytas @ git+https://github.com/jataware/archytas.git@57280acb84cd6ff2ad1f62f1220cb2ac2baab4bb",
+  "archytas @ git+https://github.com/jataware/archytas.git@33350d90a994bcd2741d8ef09bca77da746a30d4",
   "pyzmq~=26.0.2",
   "six~=1.16.0",
   "tornado~=6.4.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "matplotlib~=3.7.1",
   "xarray==0.19.0",
   "numpy~=1.24.3",
-  "archytas @ git+https://github.com/jataware/archytas.git@33350d90a994bcd2741d8ef09bca77da746a30d4",
+  "archytas~=1.1.7",
   "pyzmq~=26.0.2",
   "six~=1.16.0",
   "tornado~=6.4.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "beaker-kernel"
-version = "1.5.2"
+version = "1.5.3"
 description = ""
 readme = "README.md"
 requires-python = ">=3.10"
@@ -30,7 +30,7 @@ dependencies = [
   "matplotlib~=3.7.1",
   "xarray==0.19.0",
   "numpy~=1.24.3",
-  "archytas~=1.1.6",
+  "archytas @ git+https://github.com/jataware/archytas.git@57280acb84cd6ff2ad1f62f1220cb2ac2baab4bb",
   "pyzmq~=26.0.2",
   "six~=1.16.0",
   "tornado~=6.4.0",


### PR DESCRIPTION
This PR upgrades to the newest version of Archytas, exposes the OpenAI model as a agentclass variable and cuts a new release of Beaker. The newest version of Archytas also resolves a tool disabling on methods bug.

I created the `MODEL` class var because I thought we'd want to set the model class-wide although it's an equally valid option to stick expose an arg `model` in the `__init__` statement and default it to `gpt-4o`.

## Pre-merge checklist
- [x] [Merge in newest Archytas version PR](https://github.com/jataware/archytas/pull/31)
- [x] Update `archytas` dependency in Beaker's `pyproject.toml`