### PR TITLE
Remove package version requirements when not needed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "beaker-kernel"
-version = "1.5.4"
+version = "1.5.5"
 description = ""
 readme = "README.md"
 requires-python = ">=3.10"
@@ -22,21 +22,20 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "dill",
+  "archytas~=1.1.7",
   "jupyterlab~=4.0",
   "jupyterlab-server>=2.22.1,<3",
   "requests>=2.24,<3",
-  "pandas==1.3.3",
-  "matplotlib~=3.7.1",
-  "xarray==0.19.0",
-  "numpy~=1.24.3",
-  "archytas~=1.1.7",
-  "pyzmq~=26.0.2",
   "six~=1.16.0",
   "tornado~=6.4.0",
-  "scipy~=1.11.1",
   "jinja2~=3.1.2",
   "watchdog~=3.0",
+  "dill",
+  "pandas",
+  "matplotlib",
+  "xarray",
+  "numpy",
+  "scipy",
 ]
 
 [tool.hatch.metadata]
@@ -60,9 +59,9 @@ artifacts = [
 [tool.hatch.build.targets.wheel.shared-data]
 
 [project.urls]
-Documentation = "https://github.com/unknown/beaker-kernel#readme"
-Issues = "https://github.com/unknown/beaker-kernel/issues"
-Source = "https://github.com/unknown/beaker-kernel"
+Documentation = "https://github.com/jataware/beaker-kernel#readme"
+Issues = "https://github.com/jataware/beaker-kernel/issues"
+Source = "https://github.com/jataware/beaker-kernel"
 
 [tool.hatch.version]
 path = "beaker_kernel/__about__.py"


### PR DESCRIPTION
Have been running in to package dependency conflicts, but realized that many of the libraries that were tightly versioned don't need to be.

Double checked all the libraries and how/where they're used, and this should be safe, and allow much easier dependency resolution in the future.