### PR TITLE
Stop creating cell on session reset

### DIFF
--- a/beaker-ts/src/session.ts
+++ b/beaker-ts/src/session.ts
@@ -294,7 +294,6 @@ export class BeakerSession {
         // Remove cells via splice to ensure reactivity
         this.notebook.cells.splice(0, this.notebook.cells.length);
         this._history.clear();
-        this.addCodeCell("");
         this._sessionContext.restartKernel();
     }
 


### PR DESCRIPTION
Solves #58 without changing any behavior. [BeakerNotebook.vue is already fixing empty resets anyway](https://github.com/jataware/beaker-kernel/blob/072ca388ca44b19f49c26bb4e4aa168d2be241c3/beaker-vue/src/components/BeakerNotebook.vue#L530).