### PR TITLE
Add openpyxl

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
   "xarray",
   "numpy",
   "scipy",
+  "openpyxl",
 ]
 
 [project.scripts]


### PR DESCRIPTION
I feel like it's common enough to want to open an Excel file that we should consider having `openpyxl` built into the core of Beaker. I'm not sure of any major downside to it really but open to suggestions. It could always just live in custom contexts if this is problematic.

This also makes me think we probably do want the agent to have a `install_lib` tool where it can install libraries it needs. It isi a bit risky (e.g. if it installs some malware from pypi) but most people don't check the libs they install anyway and for exploratory data science workflows it will be common to be installing new libraries on the fly within the notebook for a specific one off task.