### PR TITLE
Fix scrollbottom on query

### DIFF
--- a/beaker-vue/src/components/agent/BeakerAgentQuery.vue
+++ b/beaker-vue/src/components/agent/BeakerAgentQuery.vue
@@ -71,6 +71,7 @@ const handleQuery = (e: any) => {
     nextTick(() => {
         notebook.selectCell(cell.id);
         beakerSession.findNotebookCellById(cell.id).execute();
+        props.runCellCallback?.(e);
     });
 }
 

--- a/beaker-vue/src/pages/DevInterface.vue
+++ b/beaker-vue/src/pages/DevInterface.vue
@@ -42,6 +42,7 @@
                         >
                             <BeakerNotebookToolbar/>
                             <BeakerNotebookPanel
+                                ref="beakerNotebookPanelRef"
                                 :selected-cell="beakerNotebookRef?.selectedCellId"
                             >
                                 <template #notebook-background>
@@ -52,6 +53,7 @@
                             </BeakerNotebookPanel>
                             <BeakerAgentQuery
                                 class="agent-query-container"
+                                :run-cell-callback="queryCallback"
                             />
                         </BeakerNotebook>
                     </div>
@@ -147,6 +149,12 @@ const toast = useToast();
 
 const activeContext = ref();
 const beakerNotebookRef = ref();
+
+// TODO(DESIGN): Scroll functionality is often going to be used outside of a `BeakerPanel`.
+//               e.g. Analyst UI. The least intrusive changes to fix scrolling were added
+//               as a minimal fix for now. 
+const beakerNotebookPanelRef = ref();
+const queryCallback = (e) => beakerNotebookPanelRef?.value?.scrollBottomCellContainer(e)
 
 
 // TODO -- WARNING: showToast is only defined locally, but provided/used everywhere. Move to session?


### PR DESCRIPTION
When pressing "enter" on query in `dev` branch, the cell panel does not scroll to bottom. This functionality has been reimplemented in a minimal way since there are changes elsewhare coming to `BeakerPanel.vue`.