### PR TITLE
Bugfix/missing history

### DIFF
--- a/beaker-ts/src/notebook.ts
+++ b/beaker-ts/src/notebook.ts
@@ -508,10 +508,20 @@ export class BeakerQueryCell extends BeakerBaseCell implements IQueryCell {
             }
         };
 
+        const notebookState = session.notebook.toIPynb();
+        notebookState.cells = notebookState.cells.filter(
+            // Skip this cell and any children of this cell
+            cell => cell.id !== this.id && cell.metadata?.parent_cell !== this.id
+        );
+
         const future = session.sendBeakerMessage(
             "llm_request",
             {
                 request: this.source
+            },
+            undefined,
+            {
+                "notebook_state": notebookState,
             }
         );
         future.onIOPub = handleIOPub;
@@ -651,6 +661,7 @@ export class BeakerNotebook {
         Object.keys(obj).forEach((key) => {
             this.content[key] = obj[key];
         })
+        this.cells = new Proxy(this.content.cells, {});
     }
 
     public loadFromIPynb(obj: any) {

--- a/beaker-ts/src/notebook.ts
+++ b/beaker-ts/src/notebook.ts
@@ -5,7 +5,7 @@ import { IShellFuture } from '@jupyterlab/services/lib/kernel/kernel';
 import { v4 as uuidv4 } from 'uuid';
 
 import { BeakerSession } from './session';
-import { IBeakerFuture, BeakerCellFuture, BeakerCellFutures } from './util';
+import { IBeakerFuture, BeakerCellFuture, BeakerCellFutures, truncateNotebookForAgent } from './util';
 
 
 export interface IBeakerHeader extends messages.IHeader<messages.MessageType> {
@@ -508,7 +508,7 @@ export class BeakerQueryCell extends BeakerBaseCell implements IQueryCell {
             }
         };
 
-        const notebookState = session.notebook.toIPynb();
+        const notebookState = truncateNotebookForAgent(session.notebook);
         notebookState.cells = notebookState.cells.filter(
             // Skip this cell and any children of this cell
             cell => cell.id !== this.id && cell.metadata?.parent_cell !== this.id
@@ -761,7 +761,7 @@ export class BeakerNotebook {
         }
     };
 
-    private content: BeakerNotebookContent;
+    public content: BeakerNotebookContent;
     public cells: IBeakerCell[];
     private subkernelInfo?: nbformat.ILanguageInfoMetadata;
 }

--- a/beaker-ts/src/session.ts
+++ b/beaker-ts/src/session.ts
@@ -136,7 +136,8 @@ export class BeakerSession {
     public sendBeakerMessage(
         messageType: string,
         content: JSONObject,
-        messageId?: string
+        messageId?: string,
+        metadata?: {[key: string]: any},
     ): IBeakerFuture {
         if (!messageId) {
             messageId = createMessageId(messageType);
@@ -149,7 +150,8 @@ export class BeakerSession {
             channel: "shell",
             msgType: messageType,
             content: content,
-            msgId: messageId
+            msgId: messageId,
+            metadata: metadata,
         });
 
         const future: IBeakerFuture<messages.IShellMessage, messages.IShellMessage> = this.kernel.sendShellMessage(

--- a/beaker-ts/src/session.ts
+++ b/beaker-ts/src/session.ts
@@ -9,7 +9,7 @@ import fetch from 'node-fetch';
 import { Slot, Signal } from '@lumino/signaling';
 import { ConnectionStatus as JupyterConnectionStatus, IAnyMessageArgs } from '@jupyterlab/services/lib/kernel/kernel';
 
-import { createMessageId, IBeakerAvailableContexts, IBeakerFuture, IActiveContextInfo } from './util';
+import { createMessageId, IBeakerAvailableContexts, IBeakerFuture, IActiveContextInfo, truncateNotebookForAgent } from './util';
 import { BeakerNotebook, IBeakerShellMessage, IBeakerAnyMessage, BeakerRawCell, BeakerCodeCell, BeakerMarkdownCell, BeakerQueryCell, IBeakerIOPubMessage } from './notebook';
 import { BeakerHistory } from './history';
 import { BeakerRenderer, IBeakerRendererOptions } from './render';
@@ -170,7 +170,7 @@ export class BeakerSession {
      * @param _sessionContext - The session Context related to the incoming message
      * @param msg - The incoming IOPub message
      */
-    private _sessionMessageHandler(_kernel: IKernelConnection, {msg, direction}: {msg: IBeakerAnyMessage, direction: IAnyMessageArgs["direction"]}) {
+    private _sessionMessageHandler(kernel: IKernelConnection, {msg, direction}: {msg: IBeakerAnyMessage, direction: IAnyMessageArgs["direction"]}) {
         if (msg.header.msg_type === "context_setup_response" || msg.header.msg_type === "context_info_response") {
             if (msg.header.msg_type === "context_setup_response") {
                 this._sessionInfo = msg.content;
@@ -182,6 +182,21 @@ export class BeakerSession {
         }
         else if (msg.header.msg_type === "kernel_info_reply") {
             this._kernelInfo = msg.content;
+        }
+        else if (msg.header.msg_type === "notebook_state_request") {
+            const outboundMsg: IBeakerShellMessage = messages.createMessage<IBeakerShellMessage>({
+                session: kernel.clientId,
+                channel: "shell",
+                msgType: "notebook_state_response",
+                content: truncateNotebookForAgent(this.notebook),
+                msgId: msg.header.msg_id + "_reply",
+                metadata: {},
+            });
+            kernel.sendShellMessage(
+                outboundMsg,
+                false,
+                true
+            );
         }
     }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "archytas~=1.3.0",
+  "archytas~=1.3.9",
   "jupyterlab~=4.0,<4.3.1",
   "jupyterlab-server>=2.22.1,<3",
   "requests>=2.24,<3",


### PR DESCRIPTION
Queries now include a representation of the notebook and the state of the subkernel environment (if available).

This currently fully works in Python and Julia, but in R we are not currently capturing the subkernel state. This can be added at a later date if needed.

If the cells contain any outputs or embedded media larger than 2048 bytes (encoded), then the value is truncated (if a string) or removed (any other type).