### PR TITLE
Config support for AWS Bedrock and Azure

### DIFF
--- a/beaker_kernel/lib/config.py
+++ b/beaker_kernel/lib/config.py
@@ -282,6 +282,11 @@ boolean value which will enable/disable the tool based on the value.",
                 "default_model_name": "mistral-nemo",
                 "api_key": ""
             },
+            "bedrock": {
+                "import_path": "archytas.models.bedrock.BedrockModel",
+                "default_model_name": "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+                "api_key": ""
+            },
         },
     )
 

--- a/beaker_kernel/lib/config.py
+++ b/beaker_kernel/lib/config.py
@@ -189,6 +189,18 @@ class LLM_Service_Provider:
         sensitive=True,
         save_default_value=True,
     )
+    region: str = configfield(
+        description="Region for the provider.",
+        default="",
+        sensitive=False,
+        save_default_value=False,
+    )
+    endpoint: str = configfield(
+        description="Endpoint URL for providers that support multiple API endpoints.",
+        default="",
+        sensitive=False,
+        save_default_value=False,
+    )
 
     @classmethod
     def default_value(cls):
@@ -286,6 +298,12 @@ boolean value which will enable/disable the tool based on the value.",
                 "import_path": "archytas.models.bedrock.BedrockModel",
                 "default_model_name": "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
                 "api_key": ""
+            },
+            "azure_openai": {
+                "import_path": "archytas.models.azure.Azure",
+                "default_model_name": "",
+                "api_key": "",
+                "endpoint": "",
             },
         },
     )

--- a/beaker_kernel/lib/config.py
+++ b/beaker_kernel/lib/config.py
@@ -201,6 +201,24 @@ class LLM_Service_Provider:
         sensitive=False,
         save_default_value=False,
     )
+    aws_access_key: str = configfield(
+        description="AWS Bedrock: access key",
+        default="",
+        sensitive=True,
+        save_default_value=False,
+    )
+    aws_secret_key: str = configfield(
+        description="AWS Bedrock: secret key",
+        default="",
+        sensitive=True,
+        save_default_value=False,
+    )
+    aws_session_token: str = configfield(
+        description="AWS Bedrock: session token",
+        default="",
+        sensitive=True,
+        save_default_value=False,
+    )
 
     @classmethod
     def default_value(cls):
@@ -297,7 +315,8 @@ boolean value which will enable/disable the tool based on the value.",
             "bedrock": {
                 "import_path": "archytas.models.bedrock.BedrockModel",
                 "default_model_name": "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
-                "api_key": ""
+                "api_key": "unused, see AWS specific keys",
+
             },
             "azure_openai": {
                 "import_path": "archytas.models.azure.Azure",


### PR DESCRIPTION
This sets up the necessary info and config fields for beaker to handle the new providers in archytas and validate the model configs.

Adding new models to beaker.conf looks like: 

```
[providers.bedrock]
import_path = "archytas.models.bedrock.BedrockModel"
default_model_name = "us.anthropic.claude-3-5-sonnet-20241022-v2:0"
api_key = ""
region = ""
endpoint = ""
aws_access_key = "---key---"
aws_secret_key = "---key---"
aws_session_token = ""

[providers.azure_openai]
import_path = "archytas.models.azure.AzureOpenAIModel"
default_model_name = "---deployment---"
api_key = "---key---"
region = ""
endpoint = "---deployment_url---"
aws_access_key = ""
aws_secret_key = ""
aws_session_token = ""
```

Or, via .env

```
AZURE_OPENAI_ENDPOINT='https://'
AZURE_OPENAI_API_KEY='--key---'
AWS_ACCESS_KEY_ID='---key---'
AWS_SECRET_KEY_ID='---key---'
```
