### PR TITLE
Add custom summarization function for run_code tool

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "archytas~=1.3.9",
+  "archytas~=1.3.16",
   "jupyterlab~=4.0,<4.3.1",
   "jupyterlab-server>=2.22.1,<3",
   "requests>=2.24,<3",


### PR DESCRIPTION
This change relies on the functionality provided in [Archytas PR #46](https://github.com/jataware/archytas/pull/46).

This add a custom summarizer function to the run_code tool which not only shrinks the size of the tool output, but also finds and shrinks the generated code in the tool call from the agent that contains the full source code.