### PR TITLE
Standardizing and modernizing menu panels

### DIFF
--- a/beaker-vue/public/themes/beaker-common.css
+++ b/beaker-vue/public/themes/beaker-common.css
@@ -152,3 +152,14 @@
 .pre {
     white-space: pre-wrap;
 }
+
+.p-button-icon.beaker-zoom {
+    &::after {
+        content: "\e908";
+        font-size: 50%;
+        position: absolute;
+        right: 38%;
+        top: 45%;
+    }
+}
+

--- a/beaker-vue/src/components/sidemenu/SideMenuPanel.vue
+++ b/beaker-vue/src/components/sidemenu/SideMenuPanel.vue
@@ -8,17 +8,28 @@
 </template>
 
 <script setup lang="tsx">
-import { defineProps, defineEmits, ref, watch } from "vue";
+import { defineProps, defineEmits, ref, watch, withDefaults, defineExpose } from "vue";
 
 const extraClasses = ref<string[]>([]);
 
-const props = defineProps([
-    "icon",
-    "label",
-    "noOverflow",
-    "lazy",
-    "selected",
-]);
+export type ButtonPosition = "top" | "bottom" | "middle";
+export interface Props {
+    "id"?: string;
+    "icon": string;
+    "label": string;
+    "noOverflow"?: boolean;
+    "lazy"?: boolean;
+    "selected"?: boolean;
+    "position"?: ButtonPosition;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+    "noOverflow": undefined,
+    "lazy": false,
+    "selected": false,
+    "position": "top",
+});
+
 const loaded = ref<boolean>(!props.lazy);
 
 if (props.noOverflow !== undefined) {
@@ -31,8 +42,7 @@ watch(props, (newProps) => {
     }
 })
 
-const emit = defineEmits([
-]);
+
 </script>
 
 

--- a/beaker-vue/src/pages/BaseInterface.vue
+++ b/beaker-vue/src/pages/BaseInterface.vue
@@ -134,15 +134,6 @@ const showToast = (options: ShowToastOptions) => {
 
 export type StyleOverride = 'chat'
 
-// const props = defineProps([
-//     "title",
-//     "titleExtra",
-//     "savefile",
-//     "headerNav",
-//     "apiKeyPrompt",
-//     "styleOverrides"
-// ]);
-
 const props = defineProps<{
   title: string
   titleExtra?: string

--- a/beaker-vue/src/pages/ChatInterface.vue
+++ b/beaker-vue/src/pages/ChatInterface.vue
@@ -48,26 +48,33 @@
         <template #left-panel>
             <SideMenu
                 position="left"
-                :show-label="true"
                 highlight="line"
                 :expanded="false"
                 initialWidth="25vi"
                 :maximized="isMaximized"
             >
-                <SideMenuPanel label="Info" icon="pi pi-home">
-                    <ContextPanel />
+                <SideMenuPanel label="Context Info" icon="pi pi-home">
+                    <InfoPanel/>
                 </SideMenuPanel>
-                <SideMenuPanel label="Files" icon="pi pi-file-export" no-overflow>
+                <SideMenuPanel id="files" label="Files" icon="pi pi-folder" no-overflow :lazy="true">
                     <FilePanel
+                        ref="filePanelRef"
                         @open-file="loadNotebook"
                         @preview-file="(file, mimetype) => {
                             previewedFile = {url: file, mimetype: mimetype};
                             previewVisible = true;
-                            rightSideMenuRef.selectPanel('Contents');
+                            rightSideMenuRef.selectPanel('file-contents');
                         }"
                     />
                 </SideMenuPanel>
-                <SideMenuPanel id="config" label="Config" icon="pi pi-cog" :lazy="true">
+                <SideMenuPanel
+                    v-if="props.config.config_type !== 'server'"
+                    id="config"
+                    :label="`${$tmpl._('short_title', 'Beaker')} Config`"
+                    icon="pi pi-cog"
+                    :lazy="true"
+                    position="bottom"
+                >
                     <ConfigPanel
                         ref="configPanelRef"
                         @restart-session="restartSession"
@@ -77,46 +84,33 @@
         </template>
         <template #right-panel>
             <SideMenu
+                ref="rightSideMenuRef"
                 position="right"
-                :show-label="true"
                 highlight="line"
                 :expanded="false"
-                ref="rightSideMenuRef"
             >
                 <SideMenuPanel label="Preview" icon="pi pi-eye" no-overflow>
                     <PreviewPanel :previewData="contextPreviewData"/>
                 </SideMenuPanel>
-                <SideMenuPanel id="file-contents" label="Contents" icon="pi pi-file" no-overflow>
+                <SideMenuPanel
+                    id="file-contents"
+                    label="File Contents"
+                    icon="pi pi-file beaker-zoom"
+                    no-overflow
+                >
                     <FileContentsPanel
                         :url="previewedFile?.url"
                         :mimetype="previewedFile?.mimetype"
-                        v-model="previewVisible"
                     />
                 </SideMenuPanel>
-                <SideMenuPanel id="media" label="Media" icon="pi pi-chart-bar" no-overflow>
-                    <MediaPanel></MediaPanel>
+                <SideMenuPanel id="media" label="Graphs and Images" icon="pi pi-chart-bar" no-overflow>
+                    <MediaPanel />
                 </SideMenuPanel>
-                <SideMenuPanel tabId="logging" label="Logging" icon="pi pi-list" >
+                <SideMenuPanel id="kernel-logs" label="Logs" icon="pi pi-list" position="bottom">
                     <DebugPanel :entries="debugLogs" @clear-logs="debugLogs.splice(0, debugLogs.length)" v-autoscroll />
                 </SideMenuPanel>
             </SideMenu>
         </template>
-                <!-- <HelpSidebar></HelpSidebar> -->
-                 <!-- <SideMenu
-                    position="right"
-                    :expanded="false"
-                    :style="{gridArea: 'r-sidebar'}"
-                    :show-label="false"
-                    :static-size="true"
-                 >
-                    <SideMenuPanel
-                        icon="pi pi-question"
-                    >
-                        <HelpSidebar/>
-                    </SideMenuPanel>
-                 </SideMenu> -->
-            <!-- </div> -->
-    <!-- </div> -->
     </BaseInterface>
 </template>
 
@@ -126,7 +120,7 @@ import AgentQuery from '../components/chat-interface/AgentQuery.vue';
 import ChatPanel from '../components/chat-interface/ChatPanel.vue';
 import SideMenu from '../components/sidemenu/SideMenu.vue';
 import SideMenuPanel from '../components/sidemenu/SideMenuPanel.vue';
-import ContextPanel from '../components/panels/ContextPanel.vue';
+import InfoPanel from '../components/panels/InfoPanel.vue';
 
 import NotebookSvg from '../assets/icon-components/NotebookSvg.vue';
 import BeakerCodeCell from '../components/cell/BeakerCodeCell.vue';

--- a/beaker-vue/src/pages/NotebookInterface.vue
+++ b/beaker-vue/src/pages/NotebookInterface.vue
@@ -59,27 +59,33 @@
             <SideMenu
                 ref="sideMenuRef"
                 position="left"
-                :show-label="true"
                 highlight="line"
                 :expanded="true"
                 initialWidth="25vi"
                 :maximized="isMaximized"
             >
-                <SideMenuPanel label="Info" icon="pi pi-home">
+                <SideMenuPanel label="Context Info" icon="pi pi-home">
                     <InfoPanel/>
                 </SideMenuPanel>
-                <SideMenuPanel id="files" label="Files" icon="pi pi-file-export" no-overflow :lazy="true">
+                <SideMenuPanel id="files" label="Files" icon="pi pi-folder" no-overflow :lazy="true">
                     <FilePanel
                         ref="filePanelRef"
                         @open-file="loadNotebook"
                         @preview-file="(file, mimetype) => {
                             previewedFile = {url: file, mimetype: mimetype};
                             previewVisible = true;
-                            rightSideMenuRef.selectPanel('Contents');
+                            rightSideMenuRef.selectPanel('file-contents');
                         }"
                     />
                 </SideMenuPanel>
-                <SideMenuPanel v-if="props.config.config_type !== 'server'" id="config" label="Config" icon="pi pi-cog" :lazy="true">
+                <SideMenuPanel
+                    v-if="props.config.config_type !== 'server'"
+                    id="config"
+                    :label="`${$tmpl._('short_title', 'Beaker')} Config`"
+                    icon="pi pi-cog"
+                    :lazy="true"
+                    position="bottom"
+                >
                     <ConfigPanel
                         ref="configPanelRef"
                         @restart-session="restartSession"
@@ -91,7 +97,6 @@
             <SideMenu
                 ref="rightSideMenuRef"
                 position="right"
-                :show-label="true"
                 highlight="line"
                 :expanded="true"
                 initialWidth="25vi"
@@ -100,20 +105,24 @@
                 <SideMenuPanel label="Preview" icon="pi pi-eye" no-overflow>
                     <PreviewPanel :previewData="contextPreviewData"/>
                 </SideMenuPanel>
-                <SideMenuPanel id="file-contents" label="Contents" icon="pi pi-file" no-overflow>
+                <SideMenuPanel
+                    id="file-contents"
+                    label="File Contents"
+                    icon="pi pi-file beaker-zoom"
+                    no-overflow
+                >
                     <FileContentsPanel
                         :url="previewedFile?.url"
                         :mimetype="previewedFile?.mimetype"
-                        v-model="previewVisible"
                     />
                 </SideMenuPanel>
-                <SideMenuPanel id="media" label="Media" icon="pi pi-chart-bar" no-overflow>
+                <SideMenuPanel id="media" label="Graphs and Images" icon="pi pi-chart-bar" no-overflow>
                     <MediaPanel />
                 </SideMenuPanel>
-                <SideMenuPanel id="kernel-state" label="State" icon="pi pi-code" no-overflow>
+                <SideMenuPanel id="kernel-state" label="Kernel State" icon="pi pi-server" no-overflow>
                     <KernelStatePanel :data="kernelStateInfo"/>
                 </SideMenuPanel>
-                <SideMenuPanel tabId="logging" label="Logging" icon="pi pi-list" >
+                <SideMenuPanel id="kernel-logs" label="Logs" icon="pi pi-list" position="bottom">
                     <DebugPanel :entries="debugLogs" @clear-logs="debugLogs.splice(0, debugLogs.length)" v-autoscroll />
                 </SideMenuPanel>
             </SideMenu>


### PR DESCRIPTION
Removes labels by default, resulting in sleeker, more standardized look.
Increased button icon size when text labels are not shown.
Replaces some of the existing button icons and labels (now in pop-over) to be better descriptive.
Added "top", "middle", and "bottom" positions to menu bar, allowing for separation of buttons.
Standardized panels and buttons between chat interface and notebook interface.

![image](https://github.com/user-attachments/assets/45a8e135-a23d-4cd1-8f36-71fd67be80bf)
![image](https://github.com/user-attachments/assets/be04a185-bc64-49e9-b479-61bf6f2842ad)
![image](https://github.com/user-attachments/assets/29e9a373-70ee-4e24-a50b-0d4e1a58b709)
