### PR TITLE
fix: trim whitespace before slugify

### DIFF
--- a/beaker_kernel/lib/utils.py
+++ b/beaker_kernel/lib/utils.py
@@ -342,5 +342,5 @@ async def ensure_async(fn: Coroutine|Callable):
         return fn
 
 def slugify(name: str):
-    slug = "_".join(re.split(r"\W", name.lower()))
+    slug = "_".join(re.split(r"\W", name.lower().strip()))
     return slug


### PR DESCRIPTION
Fixes for workflow titles that might include YAML newlines or whitespac diverging from agent context.