### PR TITLE
Fixes a rendering issue on workflows dialog; Handles server error -> updates query cell indicator to error.

### DIFF
--- a/beaker-vue/e2e/vue.spec.ts
+++ b/beaker-vue/e2e/vue.spec.ts
@@ -1,8 +1,6 @@
 import { test, expect } from '@playwright/test';
 
-// See here how to get started:
-// https://playwright.dev/docs/intro
 test('visits the app root url', async ({ page }) => {
   await page.goto('/');
-  await expect(page.locator('h1')).toHaveText('You did it!');
+  await expect(page.getByRole('heading', { name: 'Beaker Notebook' })).toBeVisible();
 })

--- a/beaker-vue/playwright.config.ts
+++ b/beaker-vue/playwright.config.ts
@@ -34,7 +34,7 @@ export default defineConfig({
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
     actionTimeout: 0,
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: process.env.CI ? 'http://localhost:4173' : 'http://localhost:5173',
+    baseURL: process.env.CI ? 'http://localhost:8888' : 'http://localhost:8080',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
@@ -51,18 +51,18 @@ export default defineConfig({
         ...devices['Desktop Chrome'],
       },
     },
-    {
-      name: 'firefox',
-      use: {
-        ...devices['Desktop Firefox'],
-      },
-    },
-    {
-      name: 'webkit',
-      use: {
-        ...devices['Desktop Safari'],
-      },
-    },
+    // {
+    //   name: 'firefox',
+    //   use: {
+    //     ...devices['Desktop Firefox'],
+    //   },
+    // },
+    // {
+    //   name: 'webkit',
+    //   use: {
+    //     ...devices['Desktop Safari'],
+    //   },
+    // },
 
     /* Test against mobile viewports. */
     // {
@@ -104,7 +104,7 @@ export default defineConfig({
      * Playwright will re-use the local server if there is already a dev-server running.
      */
     command: process.env.CI ? 'npm run preview' : 'npm run dev',
-    port: process.env.CI ? 4173 : 5173,
+    port: process.env.CI ? 8888 : 8080,
     reuseExistingServer: !process.env.CI,
   },
 })

--- a/beaker-vue/src/components/misc/WorkflowSelectDialog.vue
+++ b/beaker-vue/src/components/misc/WorkflowSelectDialog.vue
@@ -114,7 +114,7 @@ const searchResults = computed<{[key in string]: any}>(() => Object.fromEntries(
     width: 48rem;
 
     p {
-        margin-top: 0.2rem;
+        margin-top: 0.75rem;
     }
 
     .attached-workflow {
@@ -130,7 +130,6 @@ const searchResults = computed<{[key in string]: any}>(() => Object.fromEntries(
     }
     .attached-label {
         font-weight: 600;
-        flex-shrink: 0;
     }
     .card-container {
         display: flex;


### PR DESCRIPTION
A) Addresses this Workflow button/title rendering issue

Before:

<img width="1104" height="711" alt="Screenshot 2025-09-05 at 10 50 17 AM" src="https://github.com/user-attachments/assets/91f01a25-8886-4a49-9500-e69778e24195" />

After:

<img width="975" height="707" alt="Screenshot 2025-09-05 at 10 50 32 AM" src="https://github.com/user-attachments/assets/ef709de7-99fe-4c80-9c90-688b969d232c" />
---


B) Improves situation where  beaker kernel fails and the query cell was stuck in `in-progress`. Setting state as failed/error on these cases. Ran into this when the agent ran out of context (went over 200k tokens when running a workflow).

---

### Misc

Changed default/placeholder playwright test and port number to dev one 8080 in its config for playwright to run properly. Commented alt browser testing since we wouldn't need that to get started (if we do need and want to use playwright.. since it's already in the project and a very good option for e2e/int UI tests IMO).