### PR TITLE
Handle FailedTaskError in kernel llm_request

### DIFF
--- a/beaker_kernel/kernel.py
+++ b/beaker_kernel/kernel.py
@@ -525,6 +525,7 @@ class BeakerKernel(KernelProxyManager):
     @message_handler
     async def llm_request(self, message: JupyterMessage):
         from archytas.exceptions import AuthenticationError
+        from archytas.react import FailedTaskError
         content: dict = message.content
         request = content.get("request", None)
         if not request:
@@ -548,6 +549,8 @@ class BeakerKernel(KernelProxyManager):
                 task = asyncio.create_task(self.context.agent.react_async(request, react_context={"message": message}))
                 self.running_actions[request_key] = task
                 result = await task
+            except FailedTaskError as err:
+                result = err.message
             except AuthenticationError as err:
                 self.send_response(
                     stream="iopub",


### PR DESCRIPTION
This will still fail for models that require messages with `tool_calls` to be followed by tool messages corresponding to each 'tool_call_id' until this [bug fix](https://github.com/jataware/archytas/pull/72) is addressed in archytas.