### PR TITLE
Refresh integrations on context change rather than session activation

### DIFF
--- a/beaker-vue/src/pages/IntegrationsInterface.vue
+++ b/beaker-vue/src/pages/IntegrationsInterface.vue
@@ -233,20 +233,10 @@ const fetchIntegrations = async () => {
     integrations.value.finishedInitialLoad = true;
 }
 
-const activeContext = computed(() => {
-    const contextInfo = beakerSession?.value?.activeContext;
-    const kernelInfo = beakerSession?.value?.session.kernelInfo;
-    console.log(contextInfo, kernelInfo)
-    return {
-        ...contextInfo,
-        kernelInfo,
-    };
-});
-
-watch(activeContext, async () => {
-    await fetchIntegrations();
-});
-
+watch(
+    [() => beakerSession?.value?.activeContext, () => beakerSession?.value?.session.kernelInfo],
+    async () => await fetchIntegrations()
+);
 
 const modifySelectedIntegration = async (body: object, integrationId?: string) => {
     if (integrationId) {

--- a/beaker-vue/src/pages/IntegrationsInterface.vue
+++ b/beaker-vue/src/pages/IntegrationsInterface.vue
@@ -233,6 +233,21 @@ const fetchIntegrations = async () => {
     integrations.value.finishedInitialLoad = true;
 }
 
+const activeContext = computed(() => {
+    const contextInfo = beakerSession?.value?.activeContext;
+    const kernelInfo = beakerSession?.value?.session.kernelInfo;
+    console.log(contextInfo, kernelInfo)
+    return {
+        ...contextInfo,
+        kernelInfo,
+    };
+});
+
+watch(activeContext, async () => {
+    await fetchIntegrations();
+});
+
+
 const modifySelectedIntegration = async (body: object, integrationId?: string) => {
     if (integrationId) {
         integrations.value.integrations[integrationId] = await updateIntegration(

--- a/beaker-vue/src/pages/NextNotebookInterface.vue
+++ b/beaker-vue/src/pages/NextNotebookInterface.vue
@@ -360,7 +360,17 @@ type FilePreview = {
 }
 const previewedFile = ref<FilePreview>();
 
-watch(beakerSession, async () => {
+const activeContext = computed(() => {
+    const contextInfo = beakerSession?.value?.activeContext;
+    const kernelInfo = beakerSession?.value?.session.kernelInfo;
+    console.log(contextInfo, kernelInfo)
+    return {
+        ...contextInfo,
+        kernelInfo,
+    };
+});
+
+watch(activeContext, async () => {
     integrations.value = await listIntegrations(sessionIdFromUrl);
 });
 

--- a/beaker-vue/src/pages/NextNotebookInterface.vue
+++ b/beaker-vue/src/pages/NextNotebookInterface.vue
@@ -360,19 +360,10 @@ type FilePreview = {
 }
 const previewedFile = ref<FilePreview>();
 
-const activeContext = computed(() => {
-    const contextInfo = beakerSession?.value?.activeContext;
-    const kernelInfo = beakerSession?.value?.session.kernelInfo;
-    console.log(contextInfo, kernelInfo)
-    return {
-        ...contextInfo,
-        kernelInfo,
-    };
-});
-
-watch(activeContext, async () => {
-    integrations.value = await listIntegrations(sessionIdFromUrl);
-});
+watch(
+    [() => beakerSession?.value?.activeContext, () => beakerSession?.value?.session.kernelInfo],
+    async () => {integrations.value = await listIntegrations(sessionIdFromUrl)}
+);
 
 </script>
 


### PR DESCRIPTION
Resolved a bug where changing between multiple contexts with their own integrations providers would lose UI synchronization between the sidebar panel/editor and what the agent could actually use.