### PR TITLE
Pin tree-sitter languages since the packages themselves don't

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,9 +42,9 @@ dependencies = [
   "numpy",
   "scipy",
   "openpyxl",
-  "tree-sitter<0.25.0",
-  "tree-sitter-python",
-  "tree-sitter-julia",
+  "tree-sitter<0.25",
+  "tree-sitter-python<0.25",
+  "tree-sitter-julia<0.25",
 ]
 
 [project.entry-points.hatch]


### PR DESCRIPTION
Unfortunately, the tree-sitter language package don't pin themselves to the versions of tree-sitter that they are compatible with so we have to do that.