### PR TITLE
Integration hot loading

### DIFF
--- a/beaker_kernel/lib/agent.py
+++ b/beaker_kernel/lib/agent.py
@@ -59,7 +59,12 @@ class BeakerAgent(ReActAgent):
             set_tool_execution_context(tool)
 
     async def react_async(self, query: str, react_context: dict = None) -> str:
-        return await super().react_async(query, react_context)
+        try:
+            return await super().react_async(query, react_context)
+        finally:
+            # Clear loaded integration docs after each query to avoid context bloat
+            if hasattr(self.context, 'active_integrations'):
+                self.context.active_integrations.clear()
 
     async def execute(self, *args, **kwargs) -> str:
         return await super().execute(*args, **kwargs)

--- a/beaker_kernel/lib/agent.py
+++ b/beaker_kernel/lib/agent.py
@@ -58,12 +58,6 @@ class BeakerAgent(ReActAgent):
         for tool in self.tools.values():
             set_tool_execution_context(tool)
 
-    async def post_loop(self, skip_summarization: bool = False):
-        # Clear active integrations so the next query starts with just summaries
-        if hasattr(self.context, 'active_integrations'):
-            self.context.active_integrations.clear()
-        await super().post_loop(skip_summarization=skip_summarization)
-
     async def react_async(self, query: str, react_context: dict = None) -> str:
         return await super().react_async(query, react_context)
 

--- a/beaker_kernel/lib/agent.py
+++ b/beaker_kernel/lib/agent.py
@@ -59,12 +59,7 @@ class BeakerAgent(ReActAgent):
             set_tool_execution_context(tool)
 
     async def react_async(self, query: str, react_context: dict = None) -> str:
-        try:
-            return await super().react_async(query, react_context)
-        finally:
-            # Clear loaded integration docs after each query to avoid context bloat
-            if hasattr(self.context, 'active_integrations'):
-                self.context.active_integrations.clear()
+        return await super().react_async(query, react_context)
 
     async def execute(self, *args, **kwargs) -> str:
         return await super().execute(*args, **kwargs)

--- a/beaker_kernel/lib/agent.py
+++ b/beaker_kernel/lib/agent.py
@@ -58,6 +58,12 @@ class BeakerAgent(ReActAgent):
         for tool in self.tools.values():
             set_tool_execution_context(tool)
 
+    async def post_loop(self, skip_summarization: bool = False):
+        # Clear active integrations so the next query starts with just summaries
+        if hasattr(self.context, 'active_integrations'):
+            self.context.active_integrations.clear()
+        await super().post_loop(skip_summarization=skip_summarization)
+
     async def react_async(self, query: str, react_context: dict = None) -> str:
         return await super().react_async(query, react_context)
 

--- a/beaker_kernel/lib/context.py
+++ b/beaker_kernel/lib/context.py
@@ -75,6 +75,7 @@ class BeakerContext:
                  integrations: list[BaseIntegrationProvider] = None):
         self.intercepts = []
         self.integrations = integrations if integrations is not None else []
+        self.active_integrations: set[str] = set()
         self.jinja_env = None
         self.templates = {}
         self.workflows = {}
@@ -248,6 +249,15 @@ loop was running and chronologically fit "inside" the query cell, as opposed to 
                 integration.prompt for integration in self.integrations
             ]
             parts.append("---".join(integration_prompts))
+
+            # Include full documentation for integrations loaded via load_integration_docs
+            if self.active_integrations:
+                for provider in self.integrations:
+                    if hasattr(provider, 'get_rendered_docs'):
+                        for slug in list(self.active_integrations):
+                            docs = provider.get_rendered_docs(slug)
+                            if docs:
+                                parts.append(f"## Loaded Integration Documentation: {slug}\n\n{docs}")
         content = "\n\n".join(parts)
         return content
 

--- a/beaker_kernel/lib/context.py
+++ b/beaker_kernel/lib/context.py
@@ -252,12 +252,16 @@ loop was running and chronologically fit "inside" the query cell, as opposed to 
 
             # Include full documentation for integrations loaded via load_integration_docs
             if self.active_integrations:
+                logger.info(f"Active integrations for auto_context: {self.active_integrations}")
                 for provider in self.integrations:
                     if hasattr(provider, 'get_rendered_docs'):
                         for slug in list(self.active_integrations):
                             docs = provider.get_rendered_docs(slug)
                             if docs:
+                                logger.info(f"Injecting docs for '{slug}' into auto_context ({len(docs)} chars)")
                                 parts.append(f"## Loaded Integration Documentation: {slug}\n\n{docs}")
+                            else:
+                                logger.warning(f"No rendered docs found for active integration '{slug}'")
         content = "\n\n".join(parts)
         return content
 

--- a/beaker_kernel/lib/integrations/adhoc.py
+++ b/beaker_kernel/lib/integrations/adhoc.py
@@ -608,6 +608,30 @@ Returns:
         return f"Documentation for '{integration}' has been loaded into your context:\n\n{docs}"
 
     @tool
+    async def unload_integration_docs(self, integration: str, agent: AgentRef, loop: LoopControllerRef, react_context: ReactContextRef) -> str:
+        """
+Unloads a previously loaded integration's documentation from your context window. Use this after you have
+finished working with an integration to free up context space.
+
+You should call this tool when:
+- You have completed the user's task involving the integration
+- You no longer need to reference the integration's documentation
+
+Args:
+    integration (str): The name/slug of the integration to unload.
+
+Returns:
+    str: Confirmation that the documentation was unloaded.
+        """
+        if hasattr(agent, 'context') and hasattr(agent.context, 'active_integrations'):
+            if integration in agent.context.active_integrations:
+                agent.context.active_integrations.discard(integration)
+                return f"Documentation for '{integration}' has been unloaded from your context."
+            else:
+                return f"Integration '{integration}' is not currently loaded."
+        return f"Integration '{integration}' is not currently loaded."
+
+    @tool
     async def draft_integration_code(self, integration: str, goal: str, agent: AgentRef, loop: LoopControllerRef, react_context: ReactContextRef) -> str:
         """
 Drafts python code for an integration request given a specified goal, such as a query for a specific study. You can use this tool to

--- a/beaker_kernel/lib/integrations/adhoc.py
+++ b/beaker_kernel/lib/integrations/adhoc.py
@@ -369,6 +369,11 @@ class AdhocIntegrationProvider(MutableBaseIntegrationProvider):
         substitutions = {}
         # handling None cases in failed renders keeps them editable but not usable by the agent
         rendered_apis = [spec.render(self, substitutions) for spec in self.specifications]
+        # Cache rendered documentation for direct context injection via load_integration_docs
+        self._rendered_docs = {
+            api.slug: api.documentation
+            for api in rendered_apis if api is not None
+        }
         self.adhoc_api = AdhocApi(
             apis=[api for api in rendered_apis if api is not None],
             **self.adhoc_config_options
@@ -378,6 +383,10 @@ class AdhocIntegrationProvider(MutableBaseIntegrationProvider):
         # TODO: future way to not fully reinitialize to make it less slow.
         self.build_adhoc()
 
+    def get_rendered_docs(self, slug: str) -> Optional[str]:
+        """Returns the full rendered documentation for an integration by slug."""
+        return self._rendered_docs.get(slug)
+
     @property
     def prompt(self):
         agent_details = {spec.slug: spec.description for spec in self.specifications}
@@ -386,9 +395,10 @@ class AdhocIntegrationProvider(MutableBaseIntegrationProvider):
             self.prompt_instructions if self.prompt_instructions else "",
             ""
             f"{self.display_name}:",
-            "You have access to the following integrations to use with the `draft_integration_code` and `consult_integration_docs` tools,",
+            "You have access to the following integrations to use with the `draft_integration_code`, `consult_integration_docs`, and `load_integration_docs` tools,",
             "as well as their descriptions for when and why you should use the given integration, delimited in three backticks.",
-            "Only use these integrations with the `draft_integration_code` and `consult_integration_docs` tools.",
+            "Use `load_integration_docs` to load an integration's full documentation directly into your context when you need to work extensively with it.",
+            "Use `draft_integration_code` and `consult_integration_docs` for quick, targeted requests.",
             "",
             delimiter
         ]
@@ -568,6 +578,34 @@ class AdhocIntegrationProvider(MutableBaseIntegrationProvider):
             logger.warning(f"add example: failed to add resource: {e}")
             return "Add resource tool failed."
         return f"Example has been added to {integration}."
+
+    @tool
+    async def load_integration_docs(self, integration: str, agent: AgentRef, loop: LoopControllerRef, react_context: ReactContextRef) -> str:
+        """
+Loads the full documentation for an integration directly into your context window. Use this when you need to
+work extensively with an integration — for example, when writing or debugging code that interacts with the
+integration's API. Once loaded, the documentation stays in your context for the remainder of the current query,
+so you can reference it directly without additional tool calls.
+
+Prefer this tool when you anticipate multiple interactions with an integration. For quick one-off questions,
+`consult_integration_docs` or `draft_integration_code` may be more efficient.
+
+Args:
+    integration (str): The name/slug of the integration to load documentation for.
+
+Returns:
+    str: The full documentation for the integration.
+        """
+        docs = self.get_rendered_docs(integration)
+        if docs is None:
+            available = [spec.slug for spec in self.specifications]
+            return f"Integration '{integration}' not found. Available integrations: {', '.join(available)}"
+
+        # Mark integration as active on the context so auto_context includes it on subsequent turns
+        if hasattr(agent, 'context') and hasattr(agent.context, 'active_integrations'):
+            agent.context.active_integrations.add(integration)
+
+        return f"Documentation for '{integration}' has been loaded into your context:\n\n{docs}"
 
     @tool
     async def draft_integration_code(self, integration: str, goal: str, agent: AgentRef, loop: LoopControllerRef, react_context: ReactContextRef) -> str:

--- a/beaker_kernel/lib/integrations/adhoc.py
+++ b/beaker_kernel/lib/integrations/adhoc.py
@@ -371,7 +371,7 @@ class AdhocIntegrationProvider(MutableBaseIntegrationProvider):
         rendered_apis = [spec.render(self, substitutions) for spec in self.specifications]
         # Cache rendered documentation for direct context injection via load_integration_docs
         self._rendered_docs = {
-            api.slug: api.documentation
+            api["slug"]: api["documentation"]
             for api in rendered_apis if api is not None
         }
         self.adhoc_api = AdhocApi(


### PR DESCRIPTION
# Experiment Overview

This PR is **EXPERIMENTAL**: it attempts to address a challenge we have with adhoc-api: the actual code running agent remains pretty "dumb" to the integration after it calls the draft/consult integration tool(s). In long ReAct loops you see behavior where the Beaker agent struggles but doesn't re-call those tools. 

Instead, I propose a new experiment: provide the agent tools to load/unload integration docs straight into it's context window  via `auto_context`. 

The upside to this is that the agent seems to perform better overall with the integration. The downside is that the ReAct loop ends up with more tokens and costs more. Also, the agent has to remember to properly unload the integration otherwise that info will persist in the system prompt.

Additionally, if this proves viable we can **remove adhoc-api** altogether as a dependency.

## Issues and Challenges

I tried to automatically unload the integration at the end of the ReAct loop, but in certain contexts, such as Biome, the agent always presents a plan before doing work. With Claude Sonnet 4.6 it doesn't call `final_answer` or `ask_user` it just ends the ReAct loop. So understanding how and when to automatically prune the context is very tricky. The workaround is the 
`unload_integration_docs` tool, but I have concerns about the agent reliably calling this tool when appropriate. In my tests with sonnet 4.6 it did it flawlessly though.

Worst case, the agent doesn't unload the integration and we reach summarization sooner.

## Testing

I tested this with the `integration-loader` branch of Biome https://github.com/jataware/biome/tree/integration-loader where the draft/consult integration docs tools are disabled and the agent only uses the load/unload tooling.