### PR TITLE
UPDATE: Add "agent_instructions" to workflows with progressive loading

### DIFF
--- a/src/beaker_notebook/lib/context_dump.py
+++ b/src/beaker_notebook/lib/context_dump.py
@@ -370,6 +370,7 @@ def _extract_workflows(
                 "agent_description": workflow.agent_description,
                 "example_prompt": workflow.example_prompt,
                 "category_slug": workflow.category,
+                "agent_instructions": workflow.agent_instructions,
                 "hidden": workflow.hidden or False,
                 "metadata": workflow.metadata or {},
                 "stages": [

--- a/src/beaker_notebook/lib/workflow.py
+++ b/src/beaker_notebook/lib/workflow.py
@@ -186,7 +186,6 @@ class WorkflowState(TypedDict):
 
 def create_available_workflows_prompt(
     workflows: list[Workflow],
-    attached_workflow: Optional[Workflow] = None
 ) -> str:
     """
     Create a fully rendered prompt for the context based on a list of workflows and which,

--- a/src/beaker_notebook/lib/workflow.py
+++ b/src/beaker_notebook/lib/workflow.py
@@ -101,6 +101,7 @@ class Workflow:
     category: Optional[str] = field(default=None)
     metadata: Optional[dict[str, Any]] = field(default_factory=lambda: {})
     output_prompt: Optional[str] = field(default=None, metadata={"terse-action": "truncate"})
+    agent_instructions: Optional[str] = field(default=None)
 
     @staticmethod
     def from_yaml(source: dict[str, Any]) -> "Workflow":
@@ -116,25 +117,26 @@ class Workflow:
             category=source.get("category", None),
             is_context_default=source.get("is_context_default", False),
             metadata=source.get("metadata", {}),
-            output_prompt=source.get("output_prompt", None)
+            output_prompt=source.get("output_prompt", None),
+            agent_instructions=source.get("agent_instructions", None),
         )
 
     # text representation of the prompt itself, fed directly into the agent.
     def to_prompt(self) -> str:
         formatted_stages = []
         for stage in self.stages:
-            parts = [f"<stage name={stage.name!r}>"]
+            stage_parts = [f"<stage name={stage.name!r}>"]
             if stage.description:
                 desc = "\n".join(stage.description) if isinstance(stage.description, list) else stage.description
-                parts.append(f"<description>{desc}</description>")
-            parts.append("<steps>")
-            parts.extend(f"<step>{step.prompt}</step>" for step in stage.steps)
-            parts.append("</steps>")
-            parts.append("</stage>")
-            formatted_stages.append("\n".join(parts))
+                stage_parts.append(f"<description>{desc}</description>")
+            stage_parts.append("<steps>")
+            stage_parts.extend(f"<step>{step.prompt}</step>" for step in stage.steps)
+            stage_parts.append("</steps>")
+            stage_parts.append("</stage>")
+            formatted_stages.append("\n".join(stage_parts))
 
         output_prompt = self.output_prompt or "Format the result as markdown."
-        return "\n".join([
+        prompt_parts = [
             f"<title>{self.title}</title>",
             "<stages>",
             *formatted_stages,
@@ -147,7 +149,16 @@ class Workflow:
             "reader can trace any conclusion to the work that produced it.",
             "</workflow-result-formatting-instructions>",
             "",
-        ])
+        ]
+        if self.agent_instructions:
+            prompt_parts.extend([
+                "<agent-instructions>",
+                self.agent_instructions,
+                "</agent-instructions>",
+                "",
+            ])
+
+        return "\n".join(prompt_parts)
 
 
 class WorkflowStageProgress(TypedDict):

--- a/tests/test_context_dump.py
+++ b/tests/test_context_dump.py
@@ -1,0 +1,112 @@
+"""Tests for workflow extraction in lib/context_dump.py.
+
+Focused on the `agent_instructions` field: the dump must succeed whether or not
+a workflow defines it, and the value must be carried through to the extracted
+output when present.
+"""
+
+from beaker_notebook.lib.context_dump import _extract_workflows
+
+
+# A distinctive sentinel so presence/absence assertions are unambiguous.
+AGENT_INSTRUCTIONS = "SECRET-AGENT-GUIDANCE: prefer pandas over polars for this task."
+
+WORKFLOW_WITH_INSTRUCTIONS = """
+title: With Instructions
+agent_description: ad
+human_description: hd
+example_prompt: ep
+agent_instructions: |
+  {instructions}
+stages:
+  - name: s1
+    steps:
+      - do a thing
+""".format(instructions=AGENT_INSTRUCTIONS)
+
+WORKFLOW_WITHOUT_INSTRUCTIONS = """
+title: Without Instructions
+agent_description: ad
+human_description: hd
+example_prompt: ep
+stages:
+  - name: s1
+    steps:
+      - do a thing
+"""
+
+
+# Defined at module level so inspect.getfile(context_cls) resolves to this test
+# file. With an absolute `workflow_location`, _extract_workflows reads YAML from
+# that directory directly.
+class _FakeContext:
+    workflow_location = None
+
+
+def _make_context_cls(workflows_dir):
+    cls = type("_FakeWorkflowContext", (_FakeContext,), {})
+    cls.__module__ = _FakeContext.__module__
+    cls.workflow_location = str(workflows_dir)
+    return cls
+
+
+def _write_workflow(workflows_dir, name, content):
+    path = workflows_dir / name
+    path.write_text(content)
+    return path
+
+
+def test_extract_workflows_includes_agent_instructions(tmp_path):
+    workflows_dir = tmp_path / "workflows"
+    workflows_dir.mkdir()
+    _write_workflow(workflows_dir, "with.yaml", WORKFLOW_WITH_INSTRUCTIONS)
+
+    context_cls = _make_context_cls(workflows_dir)
+    all_workflows: dict = {}
+
+    refs = _extract_workflows(context_cls, str(tmp_path), all_workflows)
+
+    assert len(refs) == 1
+    assert len(all_workflows) == 1
+    extracted = next(iter(all_workflows.values()))
+    assert extracted["title"] == "With Instructions"
+    assert extracted["agent_instructions"].strip() == AGENT_INSTRUCTIONS
+
+
+def test_extract_workflows_without_agent_instructions(tmp_path):
+    workflows_dir = tmp_path / "workflows"
+    workflows_dir.mkdir()
+    _write_workflow(workflows_dir, "without.yaml", WORKFLOW_WITHOUT_INSTRUCTIONS)
+
+    context_cls = _make_context_cls(workflows_dir)
+    all_workflows: dict = {}
+
+    # The dump must succeed even when the field is absent.
+    refs = _extract_workflows(context_cls, str(tmp_path), all_workflows)
+
+    assert len(refs) == 1
+    assert len(all_workflows) == 1
+    extracted = next(iter(all_workflows.values()))
+    assert extracted["title"] == "Without Instructions"
+    # Field is always present in the output, defaulting to None.
+    assert "agent_instructions" in extracted
+    assert extracted["agent_instructions"] is None
+
+
+def test_extract_workflows_mixed(tmp_path):
+    """Both kinds of workflow extract successfully side by side."""
+    workflows_dir = tmp_path / "workflows"
+    workflows_dir.mkdir()
+    _write_workflow(workflows_dir, "with.yaml", WORKFLOW_WITH_INSTRUCTIONS)
+    _write_workflow(workflows_dir, "without.yaml", WORKFLOW_WITHOUT_INSTRUCTIONS)
+
+    context_cls = _make_context_cls(workflows_dir)
+    all_workflows: dict = {}
+
+    refs = _extract_workflows(context_cls, str(tmp_path), all_workflows)
+
+    assert len(refs) == 2
+    assert len(all_workflows) == 2
+    by_title = {w["title"]: w for w in all_workflows.values()}
+    assert by_title["With Instructions"]["agent_instructions"].strip() == AGENT_INSTRUCTIONS
+    assert by_title["Without Instructions"]["agent_instructions"] is None

--- a/tests/test_workflow_tools.py
+++ b/tests/test_workflow_tools.py
@@ -11,11 +11,12 @@ from beaker_notebook.lib.workflow import (
     WorkflowStage,
     WorkflowStep,
     WorkflowStageProgress,
+    create_available_workflows_prompt,
     workflow_condition,
 )
 
 
-def _make_workflow(title: str = "Build Pipeline") -> Workflow:
+def _make_workflow(title: str = "Build Pipeline", agent_instructions: str | None = None) -> Workflow:
     return Workflow(
         title=title,
         agent_description="agent desc",
@@ -28,6 +29,7 @@ def _make_workflow(title: str = "Build Pipeline") -> Workflow:
                 steps=[WorkflowStep(prompt="do thing")],
             )
         ],
+        agent_instructions=agent_instructions,
     )
 
 
@@ -150,3 +152,101 @@ def test_workflow_condition_reflects_attachment():
 
     agent_ref_unattached, _, _ = _make_agent_ref(workflows={"u1": wf}, attached=None)
     assert workflow_condition(agent_ref_unattached) is False
+
+
+# --- agent_instructions field ----------------------------------------------
+
+# A sentinel that is unlikely to appear incidentally in any other prompt text,
+# so assertions about its presence/absence are unambiguous.
+AGENT_INSTRUCTIONS = "SECRET-AGENT-GUIDANCE: prefer pandas over polars for this task."
+
+
+def test_from_yaml_parses_agent_instructions():
+    wf = Workflow.from_yaml({
+        "title": "T",
+        "agent_description": "a",
+        "human_description": "h",
+        "example_prompt": "e",
+        "stages": [],
+        "agent_instructions": AGENT_INSTRUCTIONS,
+    })
+    assert wf.agent_instructions == AGENT_INSTRUCTIONS
+
+
+def test_from_yaml_agent_instructions_defaults_to_none():
+    wf = Workflow.from_yaml({
+        "title": "T",
+        "agent_description": "a",
+        "human_description": "h",
+        "example_prompt": "e",
+        "stages": [],
+    })
+    assert wf.agent_instructions is None
+
+
+def test_to_prompt_includes_agent_instructions_when_set():
+    wf = _make_workflow(agent_instructions=AGENT_INSTRUCTIONS)
+    prompt = wf.to_prompt()
+    assert "<agent-instructions>" in prompt
+    assert "</agent-instructions>" in prompt
+    assert AGENT_INSTRUCTIONS in prompt
+
+
+def test_to_prompt_omits_agent_instructions_when_unset():
+    wf = _make_workflow(agent_instructions=None)
+    prompt = wf.to_prompt()
+    assert "<agent-instructions>" not in prompt
+    assert AGENT_INSTRUCTIONS not in prompt
+
+
+# --- agent_instructions are NOT in the system prompt -----------------------
+#
+# The system prompt lists the available workflows via
+# create_available_workflows_prompt / WorkflowRegistry.system_preamble. The
+# agent_instructions must not leak there; they should only become visible once
+# a workflow is actually selected (attached) and rendered via to_prompt().
+
+
+def test_available_workflows_prompt_excludes_agent_instructions():
+    wf = _make_workflow(agent_instructions=AGENT_INSTRUCTIONS)
+    prompt = create_available_workflows_prompt([wf])
+    assert AGENT_INSTRUCTIONS not in prompt
+    assert "<agent-instructions>" not in prompt
+    # the synopsis-level fields are still present
+    assert wf.title in prompt
+    assert wf.agent_description in prompt
+
+
+async def test_system_preamble_excludes_agent_instructions():
+    wf = _make_workflow(agent_instructions=AGENT_INSTRUCTIONS)
+    registry = WorkflowRegistry({"u1": wf})
+    preamble = await registry.system_preamble()
+    assert preamble is not None
+    assert AGENT_INSTRUCTIONS not in preamble
+    assert "<agent-instructions>" not in preamble
+
+
+# --- agent_instructions ARE visible once the workflow is selected ----------
+
+
+def test_attached_workflow_state_exposes_agent_instructions():
+    wf = _make_workflow(agent_instructions=AGENT_INSTRUCTIONS)
+    registry = WorkflowRegistry({"u1": wf})
+    agent_ref, _, _ = _make_agent_ref(workflows={"u1": wf}, attached=wf)
+    result = WorkflowRegistry.attached_workflow_state(registry, agent=agent_ref)
+    assert "<agent-instructions>" in result
+    assert AGENT_INSTRUCTIONS in result
+
+
+def test_agent_instructions_only_appear_after_selection():
+    """End-to-end: instructions are absent from the system preamble but present
+    once the workflow is attached and its state is rendered."""
+    wf = _make_workflow(agent_instructions=AGENT_INSTRUCTIONS)
+    registry = WorkflowRegistry({"u1": wf})
+
+    preamble = create_available_workflows_prompt(list(registry.values()))
+    assert AGENT_INSTRUCTIONS not in preamble
+
+    agent_ref, _, _ = _make_agent_ref(workflows={"u1": wf}, attached=wf)
+    attached_state = WorkflowRegistry.attached_workflow_state(registry, agent=agent_ref)
+    assert AGENT_INSTRUCTIONS in attached_state


### PR DESCRIPTION
Adds an optional "agent_instructions" field to workflow definitions. If it exists, these instructions are NOT loaded as part of the system prompt, and ARE loaded once the workflow is selected as part of the auto-state.
This is the proper place for the full instructions for the agent and rather than using the agent_description field as is sometimes done currently.

Includes tests covering behavior.

This resolves the concern behind issue #194 once workflows are updated to move long instruction text from the agent_description to the agent_instructions.