### PR TITLE
Stable workflow IDs and crash-proof discovery (#189, #193)

### DIFF
--- a/src/beaker_notebook/lib/context.py
+++ b/src/beaker_notebook/lib/context.py
@@ -14,7 +14,6 @@ from dataclasses import asdict
 from functools import wraps
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, ClassVar, Awaitable, TypedDict, Literal, TypeAlias, Collection
-from uuid import uuid4
 
 from jinja2 import Environment, FileSystemLoader, Template, select_autoescape
 from nbformat import NotebookNode
@@ -178,18 +177,10 @@ class BeakerContext:
             from beaker_notebook.lib.reflector import ReflectorRegistry
             self.subkernel.reflectors = ReflectorRegistry.from_jinja_env(self.jinja_env)
 
-        for workflow_id, workflow in self.workflows.items():
-            if workflow.is_context_default:
-                self.attach_workflow(workflow_id)
-        if not self.workflows:
-            logger.warning("Context has no workflows: disabling tools.")
-            workflow_tools = [
-                "attach_workflow",
-                "update_workflow_stage",
-                "update_workflow_output"
-            ]
-            for workflow_tool in workflow_tools:
-                self.agent.disable(workflow_tool)
+        # Attach the default workflow if one is defined.
+        if self.workflows.default is not None:
+            self.attach_workflow(self.workflows.default)
+
 
     def __init_subclass__(cls):
         mod = inspect.getmodule(cls)
@@ -448,22 +439,6 @@ class BeakerContext:
                 parts.append(
                     result
                 )
-#         if beaker_config.send_notebook_state:
-#             if self.notebook_state:
-#                 parts.append(f"""\
-# ## Current notebook
-# ```application/x-ipynb+json
-# {json.dumps(self.notebook_state)}
-# ```
-# Note: In the notebook representation above, communication with the agent is encoded as Markdown cells with metadata
-# field "beaker_cell_type" = "query". If a cell has metadata field "parent_cell", then the agent generated this cell as
-# part of the ReAct loop associated with that query. As such, cells that follow a query may have occured while the ReAact
-# loop was running and chronologically fit "inside" the query cell, as opposed to having been run afterwards.\
-# """)
-
-        # Workflows and integrations blocks have moved to system_preamble
-        # (WorkflowRegistry.system_preamble and IntegrationProviderRegistry.system_preamble).
-
         if parts:
             return "\n\n".join(parts)
         else:
@@ -871,19 +846,26 @@ class BeakerContext:
     def attached_workflow(self) -> Workflow | None:
         return self.workflows.get(self.current_workflow_state["workflow_id"], None) if self.current_workflow_state else None
 
-    def attach_workflow(self, workflow_id: str | None):
-        if workflow_id is None:
+    def attach_workflow(self, workflow: Workflow | None):
+        if workflow is None:
             self.current_workflow_state = None
         else:
-            self.current_workflow_state = WorkflowState.from_workflow(
-                workflow_id=workflow_id,
-                workflow=self.workflows[workflow_id]
-            )
+            self.current_workflow_state = WorkflowState.from_workflow(workflow)
         self.send_response("iopub", "update_workflow_state", self.current_workflow_state)
 
     @action()
     async def set_workflow(self, message):
-        self.attach_workflow(message.content["workflow"])
+        workflow_id = message.content["workflow"]
+
+        if isinstance(workflow_id, None):
+            self.attach_workflow(None)
+        elif isinstance(workflow_id, str):
+            workflow = self.workflows.get(workflow_id, None)
+            if workflow is None:
+                raise ValueError(f"Workflow with id `{workflow_id}` not found.")
+            self.attach_workflow(workflow)
+        else:
+            raise TypeError("Type of 'workflow' is expected to be a string of the workflow id or None/null to remove an active workflow.")
 
     @action(default_payload=LinterCodeCellsPayload(notebook_id='nb1', cells=[LinterCodeCellPayload(cell_id='cell1', content='import os\nos.exit(0)')]))
     async def lint_code(self, message):
@@ -948,7 +930,7 @@ class BeakerContext:
     @classmethod
     def discover_workflows(cls) -> dict:
         workflow_dir = getattr(cls, "workflow_location", None)
-        result = {}
+        workflows = {}
 
         if workflow_dir is None:
             class_dir = os.path.dirname(inspect.getfile(cls))
@@ -958,11 +940,19 @@ class BeakerContext:
             workflow_dir = os.path.normpath(os.path.join(class_dir, workflow_dir))
         if os.path.isdir(workflow_dir):
             for workflow_yaml in Path(workflow_dir).glob("*.yaml"):
-                workflow = Workflow.from_yaml(yaml.safe_load(workflow_yaml.read_text()))
-                # lives as long as the session does
-                workflow_id = str(uuid4())
-                result[workflow_id] = workflow
-        return result
+                try:
+                    workflow = Workflow.from_yaml(yaml.safe_load(workflow_yaml.read_text()))
+                except Exception as e:
+                    logger.warning("Skipping malformed workflow file %s: %s", workflow_yaml.name, e)
+                    continue
+                if workflow.id in workflows:
+                    logger.warning(
+                        "Duplicate workflow id %r from %s collides with existing workflow %r; skipping.",
+                        workflow.id, workflow_yaml.name, workflows[workflow.id].title,
+                    )
+                    continue
+                workflows[workflow.id] = workflow
+        return workflows
 
     @property
     def slug(self) -> Optional[str]:

--- a/src/beaker_notebook/lib/context.py
+++ b/src/beaker_notebook/lib/context.py
@@ -857,7 +857,7 @@ class BeakerContext:
     async def set_workflow(self, message):
         workflow_id = message.content["workflow"]
 
-        if isinstance(workflow_id, None):
+        if workflow_id is None:
             self.attach_workflow(None)
         elif isinstance(workflow_id, str):
             workflow = self.workflows.get(workflow_id, None)

--- a/src/beaker_notebook/lib/workflow.py
+++ b/src/beaker_notebook/lib/workflow.py
@@ -90,6 +90,7 @@ class WorkflowStage:
 
 @dataclass(kw_only=True)
 class Workflow:
+    id: Optional[str] = field(default=None)
     title: str
     agent_description: str = field(metadata={"terse-action": "truncate"})
     human_description: str
@@ -103,6 +104,12 @@ class Workflow:
     output_prompt: Optional[str] = field(default=None, metadata={"terse-action": "truncate"})
     agent_instructions: Optional[str] = field(default=None)
 
+    def __post_init__(self):
+        # Ensure workflows have stable IDs, creating one from the title if not included.
+        self.title = self.title.strip()
+        if not self.id:
+            self.id = slugify(self.title)
+
     @staticmethod
     def from_yaml(source: dict[str, Any]) -> "Workflow":
         stages = [WorkflowStage.from_yaml(stage) for stage in source.get("stages", [])]
@@ -113,6 +120,7 @@ class Workflow:
             example_prompt=source["example_prompt"],
             stages=stages,
 
+            id=source.get("id", None),
             hidden=source.get("hidden", None),
             category=source.get("category", None),
             is_context_default=source.get("is_context_default", False),
@@ -125,7 +133,7 @@ class Workflow:
     def to_prompt(self) -> str:
         formatted_stages = []
         for stage in self.stages:
-            stage_parts = [f"<stage name={stage.name!r}>"]
+            stage_parts = [f'<stage name="{stage.name!r}">']
             if stage.description:
                 desc = "\n".join(stage.description) if isinstance(stage.description, list) else stage.description
                 stage_parts.append(f"<description>{desc}</description>")
@@ -138,6 +146,7 @@ class Workflow:
         output_prompt = self.output_prompt or "Format the result as markdown."
         prompt_parts = [
             f"<title>{self.title}</title>",
+            f"<id>{self.id}</id>",
             "<stages>",
             *formatted_stages,
             "</stages>",
@@ -173,9 +182,9 @@ class WorkflowState(TypedDict):
     final_response: str
 
     @classmethod
-    def from_workflow(cls, workflow_id: str, workflow: Workflow) -> "WorkflowState": # type: ignore
+    def from_workflow(cls, workflow: Workflow) -> "WorkflowState": # type: ignore
         return cls(
-            workflow_id=workflow_id,
+            workflow_id=workflow.id,
             progress={
                 stage.name: None
                 for stage in workflow.stages
@@ -194,6 +203,7 @@ def create_available_workflows_prompt(
     workflow_synopsis = "\n\n".join([
         f"""<workflow>
     <title>{workflow.title}</title>
+    <id>{workflow.id}</id>
     <description>{workflow.agent_description}</description>
 </workflow>"""
         for workflow in workflows
@@ -208,8 +218,8 @@ def workflow_condition(agent: AgentRef) -> bool:
     context: BeakerContext = agent.context
     return bool(context.attached_workflow)
 
-class WorkflowRegistry(Mapping):
-    """Mapping container of workflows keyed by UUID, with a system_preamble
+class WorkflowRegistry(Mapping[str, Workflow]):
+    """Mapping container of workflows keyed by id, with a system_preamble
     contribution that lists the available workflows for the agent.
 
     Mirrors the role of IntegrationProviderRegistry: holds a collection and
@@ -231,13 +241,20 @@ class WorkflowRegistry(Mapping):
     def __bool__(self) -> bool:
         return bool(self._workflows)
 
+    @property
+    def default(self) -> Workflow|None:
+        for workflow in self.values():
+            if workflow.is_context_default:
+                return workflow
+        return None
+
     async def system_preamble(self) -> Optional[str]:
         if not self._workflows:
             return None
         return create_available_workflows_prompt(list(self._workflows.values()))
 
     @tool(internal=True)
-    async def attach_workflow(self, workflow_title: str, agent: AgentRef):
+    async def attach_workflow(self, workflow_id: str|None, agent: AgentRef):
         """
         Chooses a relevant workflow to the user's request and attaches it to the context.
 
@@ -248,27 +265,26 @@ class WorkflowRegistry(Mapping):
         If they describe what they want to do, choose the most relevant workflow based on their query.
 
         Args:
-            workflow_title (str): The title of the workflow that you have access to, most relevant to their query.
-                            This is "none" if the user wants to detach, remove, or unset the workflow.
+            workflow_id (str|None): The id of an available workflow that you wish to attach, or None to detach the workflow.
 
         Returns:
             str: A summary of what was done
         """
         try:
-            if len(agent.context.workflows) == 0:
-                return "No workflows attached to context."
+            if len(self) == 0:
+                return "No workflows in registry."
         except Exception as e:
             return f"Failed to get workflows on context. {e}"
-        desired = slugify(workflow_title)
-        titles = {
-            slugify(workflow.title): uuid
-            for uuid, workflow in agent.context.workflows.items()
-        }
-        if desired not in titles:
-            return f"Failed to find `{desired}` in `{titles}`: invalid tool input."
-        agent.context.attach_workflow(titles[desired])
+        if workflow_id is None:
+            workflow = None
+        else:
+            workflow = self.get(workflow_id, None)
+            if workflow is None:
+                return f"Failed to find workflow with id `{workflow_id}`. Existing workflows: `{(list(self.keys()))!r}`: invalid tool input."
+
+        agent.context.attach_workflow(workflow)
         agent.context.send_response("iopub", "update_workflow_state", agent.context.current_workflow_state)
-        return f"Successfully set the attached workflow to {workflow_title}."
+        return f'Successfully set the attached workflow to "{workflow.title}" ({workflow.id}).'
 
     @tool(internal=True)
     async def update_workflow_stage(self, stage_name: str, state: str, results: str, agent: AgentRef):

--- a/tests/import_shim/test_workflow_tools.py
+++ b/tests/import_shim/test_workflow_tools.py
@@ -15,9 +15,10 @@ from beaker_kernel.lib.workflow import (
 )
 
 
-def _make_workflow(title: str = "Build Pipeline") -> Workflow:
+def _make_workflow(title: str = "Build Pipeline", id: str = None, agent_instructions: str | None = None) -> Workflow:
     return Workflow(
         title=title,
+        id=id,
         agent_description="agent desc",
         human_description="human desc",
         example_prompt="example",
@@ -65,17 +66,34 @@ async def test_attach_workflow_unknown_title():
     assert "Failed to find" in result
 
 
-async def test_attach_workflow_success_calls_context_attach():
+async def test_attach_workflow_success_calls_context_attach_no_id():
     wf = _make_workflow("Build Pipeline")
-    registry = WorkflowRegistry({"u1": wf})
-    agent_ref, _, ctx = _make_agent_ref(workflows={"u1": wf})
+    workflow_id = wf.id
+    registry = WorkflowRegistry({workflow_id: wf})
+    agent_ref, _, ctx = _make_agent_ref(workflows=registry)
 
-    result = await WorkflowRegistry.attach_workflow(registry, "Build Pipeline", agent=agent_ref)
+    result = await WorkflowRegistry.attach_workflow.run(args={"workflow_id": workflow_id, "agent": agent_ref}, tool_context={"agent": agent_ref}, self_ref=registry)
 
+    assert isinstance(workflow_id, str)
+    assert len(workflow_id) > 0
     assert "Successfully" in result
-    ctx.attach_workflow.assert_called_once_with("u1")
+    assert workflow_id in result
+    ctx.attach_workflow.assert_called_once_with(wf)
     ctx.send_response.assert_called_once()
 
+
+async def test_attach_workflow_success_calls_context_attach_with_id():
+    workflow_id = "build_pipeline_id"
+    wf = _make_workflow("Build Pipeline", id=workflow_id)
+    registry = WorkflowRegistry({workflow_id: wf})
+    agent_ref, _, ctx = _make_agent_ref(workflows=registry)
+
+    result = await WorkflowRegistry.attach_workflow.run(args={"workflow_id": workflow_id, "agent": agent_ref}, tool_context={"agent": agent_ref}, self_ref=registry)
+
+    assert "Successfully" in result
+    assert workflow_id in result
+    ctx.attach_workflow.assert_called_once_with(wf)
+    ctx.send_response.assert_called_once()
 
 # --- update_workflow_stage -------------------------------------------------
 

--- a/tests/test_discover_workflows.py
+++ b/tests/test_discover_workflows.py
@@ -1,0 +1,180 @@
+"""Tests for BeakerContext.discover_workflows (lib/context.py).
+
+Covers issue #189 (crash-proof YAML discovery) and issue #193 (stable,
+slug-derived workflow ids with collision rejection), plus the construction-time
+auto-attach of a default workflow.
+"""
+
+import logging
+from unittest.mock import MagicMock
+
+from beaker_notebook.lib.context import BeakerContext
+from beaker_notebook.lib.utils import slugify
+
+
+def _valid_yaml(title: str, *, is_context_default: bool = False) -> str:
+    lines = [
+        f"title: {title}",
+        "agent_description: agent desc",
+        "human_description: human desc",
+        "example_prompt: example",
+    ]
+    if is_context_default:
+        lines.append("is_context_default: true")
+    lines += [
+        "stages:",
+        "  - name: stage_one",
+        "    description: first stage",
+        "    steps:",
+        "      - prompt: do thing",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def _make_context_class(workflow_dir):
+    class _TestContext(BeakerContext):
+        workflow_location = str(workflow_dir)
+
+    return _TestContext
+
+
+def test_discover_skips_broken_and_loads_valid(tmp_path, caplog):
+    (tmp_path / "good_one.yaml").write_text(_valid_yaml("Build Pipeline"))
+    (tmp_path / "good_two.yaml").write_text(_valid_yaml("Run Analysis"))
+    # Malformed: missing required key (agent_description).
+    (tmp_path / "broken.yaml").write_text("title: Broken Only\n")
+
+    ctx_cls = _make_context_class(tmp_path)
+    with caplog.at_level(logging.WARNING):
+        result = ctx_cls.discover_workflows()
+
+    assert len(result) == 2
+    titles = {wf.title for wf in result.values()}
+    assert titles == {"Build Pipeline", "Run Analysis"}
+    assert any("broken.yaml" in rec.message for rec in caplog.records)
+
+
+def test_discover_skips_invalid_yaml(tmp_path, caplog):
+    (tmp_path / "good.yaml").write_text(_valid_yaml("Build Pipeline"))
+    # Not parseable as YAML.
+    (tmp_path / "bad.yaml").write_text("title: : :\n  - [unbalanced\n")
+
+    ctx_cls = _make_context_class(tmp_path)
+    with caplog.at_level(logging.WARNING):
+        result = ctx_cls.discover_workflows()
+
+    assert len(result) == 1
+    assert any("bad.yaml" in rec.message for rec in caplog.records)
+
+
+def test_discover_ids_are_stable_across_calls(tmp_path):
+    (tmp_path / "one.yaml").write_text(_valid_yaml("Build Pipeline"))
+    ctx_cls = _make_context_class(tmp_path)
+
+    first = ctx_cls.discover_workflows()
+    second = ctx_cls.discover_workflows()
+
+    assert list(first.keys()) == list(second.keys())
+    assert slugify("Build Pipeline") in first
+
+
+def test_discover_id_is_slugified_title(tmp_path):
+    (tmp_path / "one.yaml").write_text(_valid_yaml("Build Pipeline"))
+    ctx_cls = _make_context_class(tmp_path)
+
+    result = ctx_cls.discover_workflows()
+
+    assert set(result.keys()) == {slugify("Build Pipeline")}
+
+
+def test_discover_slug_collision_keeps_first(tmp_path, caplog):
+    # Both titles slugify to the same value ("build_pipeline").
+    (tmp_path / "a_first.yaml").write_text(_valid_yaml("Build Pipeline"))
+    (tmp_path / "z_second.yaml").write_text(_valid_yaml("BUILD pipeline"))
+
+    ctx_cls = _make_context_class(tmp_path)
+    with caplog.at_level(logging.WARNING):
+        result = ctx_cls.discover_workflows()
+
+    assert len(result) == 1
+    # glob order is filesystem-dependent; assert exactly one survived and a
+    # collision warning naming the skipped file/title was logged.
+    assert slugify("Build Pipeline") in result
+    assert any("Duplicate workflow id" in rec.message for rec in caplog.records)
+
+
+# --- construction-time default-workflow auto-attach ------------------------
+#
+# A workflow marked `is_context_default: true` must be attached during
+# BeakerContext.__init__. attach_workflow -> send_response dereferences
+# self.beaker_kernel, so the attach must run *after* beaker_kernel is assigned.
+# Regression guard: an earlier refactor attached the default before
+# self.beaker_kernel existed, raising AttributeError at construction.
+
+
+class _StubAgent:
+    """Minimal stand-in for BeakerAgent that __init__ can construct and poke."""
+
+    def __init__(self, context, tools):
+        self.context = context
+        self.tools = tools
+        self.chat_history = None
+
+    def disable(self, *names):
+        pass
+
+    def set_auto_context(self, *args, **kwargs):
+        pass
+
+
+class _StubSubkernel:
+    SLUG = "stub"
+    tools: list = []
+
+    def _resolve_procedure_dirs(self):
+        return []
+
+
+def _make_constructible_context_class(workflow_dir):
+    class _TestContext(BeakerContext):
+        AGENT_CLS = _StubAgent
+        workflow_location = str(workflow_dir)
+
+        def get_subkernel(self):
+            return _StubSubkernel()
+
+    return _TestContext
+
+
+def test_default_workflow_attached_during_init(tmp_path):
+    (tmp_path / "default.yaml").write_text(
+        _valid_yaml("Build Pipeline", is_context_default=True)
+    )
+    (tmp_path / "other.yaml").write_text(_valid_yaml("Run Analysis"))
+
+    ctx_cls = _make_constructible_context_class(tmp_path)
+    kernel = MagicMock()
+
+    # Constructing must not raise (the regression raised AttributeError because
+    # the default was attached before self.beaker_kernel was set).
+    ctx = ctx_cls(beaker_kernel=kernel)
+
+    assert ctx.current_workflow_state is not None
+    assert ctx.current_workflow_state["workflow_id"] == slugify("Build Pipeline")
+    # The attach went through send_response on the (already-wired) kernel.
+    # send_response forwards extra positional args (channel, parent_header, ...),
+    # so match only the leading (stream, msg_type, content) triple.
+    assert any(
+        call.args[:3]
+        == ("iopub", "update_workflow_state", ctx.current_workflow_state)
+        for call in kernel.send_response.call_args_list
+    )
+
+
+def test_no_default_workflow_leaves_state_unattached(tmp_path):
+    (tmp_path / "other.yaml").write_text(_valid_yaml("Run Analysis"))
+
+    ctx_cls = _make_constructible_context_class(tmp_path)
+    ctx = ctx_cls(beaker_kernel=MagicMock())
+
+    assert ctx.current_workflow_state is None

--- a/tests/test_workflow_tools.py
+++ b/tests/test_workflow_tools.py
@@ -16,9 +16,10 @@ from beaker_notebook.lib.workflow import (
 )
 
 
-def _make_workflow(title: str = "Build Pipeline", agent_instructions: str | None = None) -> Workflow:
+def _make_workflow(title: str = "Build Pipeline", id: str = None, agent_instructions: str | None = None) -> Workflow:
     return Workflow(
         title=title,
+        id=id,
         agent_description="agent desc",
         human_description="human desc",
         example_prompt="example",
@@ -67,15 +68,33 @@ async def test_attach_workflow_unknown_title():
     assert "Failed to find" in result
 
 
-async def test_attach_workflow_success_calls_context_attach():
+async def test_attach_workflow_success_calls_context_attach_no_id():
     wf = _make_workflow("Build Pipeline")
-    registry = WorkflowRegistry({"u1": wf})
-    agent_ref, _, ctx = _make_agent_ref(workflows={"u1": wf})
+    workflow_id = wf.id
+    registry = WorkflowRegistry({workflow_id: wf})
+    agent_ref, _, ctx = _make_agent_ref(workflows=registry)
 
-    result = await WorkflowRegistry.attach_workflow(registry, "Build Pipeline", agent=agent_ref)
+    result = await WorkflowRegistry.attach_workflow.run(args={"workflow_id": workflow_id, "agent": agent_ref}, tool_context={"agent": agent_ref}, self_ref=registry)
+
+    assert isinstance(workflow_id, str)
+    assert len(workflow_id) > 0
+    assert "Successfully" in result
+    assert workflow_id in result
+    ctx.attach_workflow.assert_called_once_with(wf)
+    ctx.send_response.assert_called_once()
+
+
+async def test_attach_workflow_success_calls_context_attach_with_id():
+    workflow_id = "build_pipeline_id"
+    wf = _make_workflow("Build Pipeline", id=workflow_id)
+    registry = WorkflowRegistry({workflow_id: wf})
+    agent_ref, _, ctx = _make_agent_ref(workflows=registry)
+
+    result = await WorkflowRegistry.attach_workflow.run(args={"workflow_id": workflow_id, "agent": agent_ref}, tool_context={"agent": agent_ref}, self_ref=registry)
 
     assert "Successfully" in result
-    ctx.attach_workflow.assert_called_once_with("u1")
+    assert workflow_id in result
+    ctx.attach_workflow.assert_called_once_with(wf)
     ctx.send_response.assert_called_once()
 
 


### PR DESCRIPTION
Resolves issues #189 & #193

Gives workflows a stable identity and stop a single bad file from taking down context startup.

- #193: Workflow now carries an `id` (explicit `id:` in YAML, else the slugified title), assigned in __post_init__. discover_workflows() keys the registry on workflow.id instead of a per-session uuid4(), so the same file yields the same id across sessions. Title-slug collisions are rejected at load time with a logged warning, keeping the first.
- #189: Each workflow file load is wrapped in try/except; malformed YAML or missing required keys are logged at warning level and skipped, so the remaining valid workflows still load.

Supporting changes:
- attach_workflow / set_workflow / WorkflowState.from_workflow take a Workflow object; the attach_workflow tool takes a workflow_id (or None to detach) rather than matching on title.
- Default-workflow attachment simplified.
- Removed dead commented-out code in context.py.
- Tests for discovery (skip-broken, stable ids, collision) and updated workflow-tool tests.