### PR TITLE
Improve update_workflow_stage: lenient matching, invariant checks, agent cursor (#190, #191, #192)

### DIFF
--- a/src/beaker_notebook/lib/utils.py
+++ b/src/beaker_notebook/lib/utils.py
@@ -354,8 +354,9 @@ async def ensure_async(fn: Coroutine|Callable):
     else:
         return fn
 
-def slugify(name: str):
-    slug = "_".join(re.split(r"\W", name.lower().strip()))
+def slugify(name: str, collapse: bool = False):
+    pattern = r"[\W_]+" if collapse else r"\W"
+    slug = "_".join(re.split(pattern, name.lower().strip()))
     return slug
 
 def url_path_join(*pieces: str) -> str:

--- a/src/beaker_notebook/lib/workflow.py
+++ b/src/beaker_notebook/lib/workflow.py
@@ -302,7 +302,8 @@ class WorkflowRegistry(Mapping[str, Workflow]):
 
         Args:
             stage_name (str): The name of the stage to mark as completed to the user.
-                            IMPORTANT: This must be the exact name of the stage.
+                            This is matched leniently (case/punctuation/whitespace
+                            insensitive) against the workflow's stage names.
             state (str): State will always either one of 'in_progress' or 'finished'.
                         If finished, results must not be blank.
                         If the stage is now in progress, results should be blank.
@@ -315,16 +316,103 @@ class WorkflowRegistry(Mapping[str, Workflow]):
         """
         if state != 'in_progress' and state != 'finished':
             return "State must be one of `in_progress` or `finished`."
-        if stage_name not in agent.context.current_workflow_state["progress"]:
-            return f"Stage name not found. Must be one of: {agent.context.current_workflow_state['progress'].keys()}"
-        agent.context.current_workflow_state["progress"][stage_name] = WorkflowStageProgress(
-                code_cell_id='',
-                state=state,
-                results_markdown=results,
+
+        # Resolve the agent's input to the canonical stored stage key via slugify on both sides.
+        progress = agent.context.current_workflow_state["progress"]
+        resolved_key = None
+        desired = slugify(stage_name, collapse=True)
+        for key in progress:
+            if slugify(key, collapse=True) == desired:
+                resolved_key = key
+                break
+        if resolved_key is None:
+            stage_list = ", ".join(progress.keys())
+            return f"Stage name not found. Must be one of: {stage_list}"
+
+        results_blank = not results.strip()
+        if state == 'finished' and results_blank:
+            return (
+                f"Stage '{resolved_key}' was not modified. When marking a stage "
+                "'finished', you must supply the stage's results in markdown."
+            )
+        if state == 'in_progress' and not results_blank:
+            return (
+                f"Stage '{resolved_key}' was not modified. When marking a stage "
+                "'in_progress', results must be blank."
             )
 
+        # Collect skipped stages (earlier stages that have not yet been started) so we can warn the agent.
+        skipped_stages: list[str] = []
+        if state == 'finished':
+            for key, value in progress.items():
+                if key == resolved_key:
+                    break
+                if value is None:
+                    skipped_stages.append(key)
+
+        progress[resolved_key] = WorkflowStageProgress(
+            code_cell_id='',
+            state=state,
+            results_markdown=results,
+        )
+
         agent.context.send_response("iopub", "update_workflow_state", agent.context.current_workflow_state)
-        return "Successfully marked stage."
+
+        return self._build_stage_response(agent, resolved_key, state, skipped_stages)
+
+    def _build_stage_response(
+        self,
+        agent: AgentRef,
+        resolved_key: str,
+        state: str,
+        skipped_stages: list[str],
+    ) -> str:
+        """Build the instructive return string for `update_workflow_stage`.
+
+        Re-grounds the agent at every transition: its position (`N of M`), and,
+        when finishing a non-final stage, the next stage's name and steps.
+        """
+        progress_keys = list(agent.context.current_workflow_state["progress"].keys())
+        total = len(progress_keys)
+        index = progress_keys.index(resolved_key)  # zero-based
+        position = f"Stage {index + 1} of {total}"
+
+        next_key: Optional[str] = (
+            progress_keys[index + 1] if index + 1 < total else None
+        )
+
+        workflow = agent.context.attached_workflow
+        stages_by_name: dict[str, WorkflowStage] = {}
+        if workflow is not None:
+            stages_by_name = {stage.name: stage for stage in workflow.stages}
+
+        lines: list[str] = []
+        if state == 'in_progress':
+            lines.append(f'{position} ("{resolved_key}") is now in progress.')
+        else:
+            lines.append(f'{position} ("{resolved_key}") marked finished.')
+            if next_key is None:
+                lines.append(
+                    "The workflow is now complete. Call `update_workflow_output` "
+                    "with the cumulative results for the entire workflow."
+                )
+            else:
+                next_position = f"Stage {index + 2} of {total}"
+                lines.append(f'Next stage: "{next_key}" ({next_position}) — steps:')
+                next_stage = stages_by_name.get(next_key)
+                if next_stage is not None and next_stage.steps:
+                    for i, step in enumerate(next_stage.steps, start=1):
+                        lines.append(f"  {i}. {step.prompt}")
+
+        if skipped_stages:
+            skipped_list = ", ".join(f'"{name}"' for name in skipped_stages)
+            lines.append(
+                f"Warning: the following earlier stage(s) are still unstarted: "
+                f"{skipped_list}. If this was intentional (e.g. redoing work), "
+                "you may continue; otherwise make sure no stages were skipped."
+            )
+
+        return "\n".join(lines)
 
     @tool(internal=True)
     async def update_workflow_output(self, results: str, agent: AgentRef):

--- a/tests/import_shim/test_workflow_tools.py
+++ b/tests/import_shim/test_workflow_tools.py
@@ -32,10 +32,16 @@ def _make_workflow(title: str = "Build Pipeline", id: str = None, agent_instruct
     )
 
 
-def _make_agent_ref(workflows: dict, attached: Workflow | None = None):
+def _make_agent_ref(
+    workflows: dict,
+    attached: Workflow | None = None,
+    progress: dict | None = None,
+):
+    if progress is None:
+        progress = {"stage_one": None}
     state = {
         "workflow_id": "wf-uuid",
-        "progress": {"stage_one": None},
+        "progress": progress,
         "final_response": "",
     }
     context = SimpleNamespace(
@@ -46,6 +52,42 @@ def _make_agent_ref(workflows: dict, attached: Workflow | None = None):
         send_response=MagicMock(),
     )
     return SimpleNamespace(context=context), state, context
+
+
+def _make_multistage_workflow(title: str = "Weather Report") -> Workflow:
+    return Workflow(
+        title=title,
+        agent_description="agent desc",
+        human_description="human desc",
+        example_prompt="example",
+        stages=[
+            WorkflowStage(
+                name="Collect METAR data",
+                description="first stage",
+                steps=[WorkflowStep(prompt="fetch the data")],
+            ),
+            WorkflowStage(
+                name="Assess flight conditions",
+                description="second stage",
+                steps=[
+                    WorkflowStep(prompt="evaluate ceilings"),
+                    WorkflowStep(prompt="evaluate visibility"),
+                ],
+            ),
+            WorkflowStage(
+                name="Summarize",
+                description="third stage",
+                steps=[WorkflowStep(prompt="write summary")],
+            ),
+        ],
+    )
+
+
+def _multistage_agent_ref(attached: Workflow):
+    progress = {stage.name: None for stage in attached.stages}
+    return _make_agent_ref(
+        workflows={"u1": attached}, attached=attached, progress=progress,
+    )
 
 
 # --- attach_workflow -------------------------------------------------------
@@ -117,16 +159,157 @@ async def test_update_workflow_stage_unknown_stage():
 
 
 async def test_update_workflow_stage_writes_progress():
+    wf = _make_workflow()
     registry = WorkflowRegistry()
-    agent_ref, state, ctx = _make_agent_ref(workflows={})
+    agent_ref, state, ctx = _make_agent_ref(workflows={"u1": wf}, attached=wf)
     result = await WorkflowRegistry.update_workflow_stage(
         registry, stage_name="stage_one", state="finished", results="done", agent=agent_ref,
     )
-    assert "Successfully" in result
     progress = state["progress"]["stage_one"]
     assert progress["state"] == "finished"
     assert progress["results_markdown"] == "done"
     ctx.send_response.assert_called_once()
+    # single-stage workflow finished -> completion message
+    assert "Stage 1 of 1" in result
+    assert "complete" in result.lower()
+    assert "update_workflow_output" in result
+
+
+# --- #191: slug matching + clean error message -----------------------------
+
+
+async def test_update_workflow_stage_unknown_stage_message_has_no_dict_keys():
+    wf = _make_multistage_workflow()
+    registry = WorkflowRegistry()
+    agent_ref, _, _ = _multistage_agent_ref(wf)
+    result = await WorkflowRegistry.update_workflow_stage(
+        registry, stage_name="nonexistent", state="finished", results="r", agent=agent_ref,
+    )
+    assert "Stage name not found" in result
+    assert "dict_keys" not in result
+    assert "[" not in result
+    assert "Collect METAR data" in result
+    assert "Assess flight conditions" in result
+
+
+async def test_update_workflow_stage_slug_match_resolves_variant():
+    wf = _make_multistage_workflow()
+    registry = WorkflowRegistry()
+    agent_ref, state, _ = _multistage_agent_ref(wf)
+    # differs in case/punctuation/whitespace from "Collect METAR data"
+    result = await WorkflowRegistry.update_workflow_stage(
+        registry,
+        stage_name=" Collect METAR-data ",
+        state="finished",
+        results="data collected",
+        agent=agent_ref,
+    )
+    assert "Stage name not found" not in result
+    # canonical key was the one mutated
+    assert state["progress"]["Collect METAR data"]["state"] == "finished"
+
+
+# --- #192: invariant enforcement -------------------------------------------
+
+
+async def test_update_workflow_stage_finished_blank_results_rejected():
+    wf = _make_multistage_workflow()
+    registry = WorkflowRegistry()
+    agent_ref, state, ctx = _multistage_agent_ref(wf)
+    result = await WorkflowRegistry.update_workflow_stage(
+        registry,
+        stage_name="Collect METAR data",
+        state="finished",
+        results="   ",
+        agent=agent_ref,
+    )
+    assert "not modified" in result
+    assert state["progress"]["Collect METAR data"] is None
+    ctx.send_response.assert_not_called()
+
+
+async def test_update_workflow_stage_in_progress_nonblank_results_rejected():
+    wf = _make_multistage_workflow()
+    registry = WorkflowRegistry()
+    agent_ref, state, ctx = _multistage_agent_ref(wf)
+    result = await WorkflowRegistry.update_workflow_stage(
+        registry,
+        stage_name="Collect METAR data",
+        state="in_progress",
+        results="some results",
+        agent=agent_ref,
+    )
+    assert "not modified" in result
+    assert state["progress"]["Collect METAR data"] is None
+    ctx.send_response.assert_not_called()
+
+
+async def test_update_workflow_stage_out_of_order_finish_warns_but_records():
+    wf = _make_multistage_workflow()
+    registry = WorkflowRegistry()
+    agent_ref, state, _ = _multistage_agent_ref(wf)
+    # finish the 2nd stage while the 1st is still unstarted
+    result = await WorkflowRegistry.update_workflow_stage(
+        registry,
+        stage_name="Assess flight conditions",
+        state="finished",
+        results="conditions ok",
+        agent=agent_ref,
+    )
+    assert state["progress"]["Assess flight conditions"]["state"] == "finished"
+    assert "Warning" in result
+    assert "Collect METAR data" in result
+
+
+# --- #190: cursor / re-grounding in the return value -----------------------
+
+
+async def test_update_workflow_stage_finished_nonfinal_names_next_stage_and_steps():
+    wf = _make_multistage_workflow()
+    registry = WorkflowRegistry()
+    agent_ref, _, _ = _multistage_agent_ref(wf)
+    result = await WorkflowRegistry.update_workflow_stage(
+        registry,
+        stage_name="Collect METAR data",
+        state="finished",
+        results="data",
+        agent=agent_ref,
+    )
+    assert "Stage 1 of 3" in result
+    assert 'Next stage: "Assess flight conditions"' in result
+    assert "evaluate ceilings" in result
+    assert "evaluate visibility" in result
+
+
+async def test_update_workflow_stage_finished_final_states_complete():
+    wf = _make_multistage_workflow()
+    registry = WorkflowRegistry()
+    agent_ref, _, _ = _multistage_agent_ref(wf)
+    result = await WorkflowRegistry.update_workflow_stage(
+        registry,
+        stage_name="Summarize",
+        state="finished",
+        results="summary",
+        agent=agent_ref,
+    )
+    assert "Stage 3 of 3" in result
+    assert "complete" in result.lower()
+    assert "update_workflow_output" in result
+
+
+async def test_update_workflow_stage_in_progress_confirms_position():
+    wf = _make_multistage_workflow()
+    registry = WorkflowRegistry()
+    agent_ref, _, _ = _multistage_agent_ref(wf)
+    result = await WorkflowRegistry.update_workflow_stage(
+        registry,
+        stage_name="Assess flight conditions",
+        state="in_progress",
+        results="",
+        agent=agent_ref,
+    )
+    assert "Stage 2 of 3" in result
+    assert "in progress" in result.lower()
 
 
 # --- update_workflow_output ------------------------------------------------

--- a/tests/test_workflow_tools.py
+++ b/tests/test_workflow_tools.py
@@ -34,10 +34,16 @@ def _make_workflow(title: str = "Build Pipeline", id: str = None, agent_instruct
     )
 
 
-def _make_agent_ref(workflows: dict, attached: Workflow | None = None):
+def _make_agent_ref(
+    workflows: dict,
+    attached: Workflow | None = None,
+    progress: dict | None = None,
+):
+    if progress is None:
+        progress = {"stage_one": None}
     state = {
         "workflow_id": "wf-uuid",
-        "progress": {"stage_one": None},
+        "progress": progress,
         "final_response": "",
     }
     context = SimpleNamespace(
@@ -48,6 +54,42 @@ def _make_agent_ref(workflows: dict, attached: Workflow | None = None):
         send_response=MagicMock(),
     )
     return SimpleNamespace(context=context), state, context
+
+
+def _make_multistage_workflow(title: str = "Weather Report") -> Workflow:
+    return Workflow(
+        title=title,
+        agent_description="agent desc",
+        human_description="human desc",
+        example_prompt="example",
+        stages=[
+            WorkflowStage(
+                name="Collect METAR data",
+                description="first stage",
+                steps=[WorkflowStep(prompt="fetch the data")],
+            ),
+            WorkflowStage(
+                name="Assess flight conditions",
+                description="second stage",
+                steps=[
+                    WorkflowStep(prompt="evaluate ceilings"),
+                    WorkflowStep(prompt="evaluate visibility"),
+                ],
+            ),
+            WorkflowStage(
+                name="Summarize",
+                description="third stage",
+                steps=[WorkflowStep(prompt="write summary")],
+            ),
+        ],
+    )
+
+
+def _multistage_agent_ref(attached: Workflow):
+    progress = {stage.name: None for stage in attached.stages}
+    return _make_agent_ref(
+        workflows={"u1": attached}, attached=attached, progress=progress,
+    )
 
 
 # --- attach_workflow -------------------------------------------------------
@@ -120,16 +162,206 @@ async def test_update_workflow_stage_unknown_stage():
 
 
 async def test_update_workflow_stage_writes_progress():
+    wf = _make_workflow()
     registry = WorkflowRegistry()
-    agent_ref, state, ctx = _make_agent_ref(workflows={})
+    agent_ref, state, ctx = _make_agent_ref(workflows={"u1": wf}, attached=wf)
     result = await WorkflowRegistry.update_workflow_stage(
         registry, stage_name="stage_one", state="finished", results="done", agent=agent_ref,
     )
-    assert "Successfully" in result
     progress = state["progress"]["stage_one"]
     assert progress["state"] == "finished"
     assert progress["results_markdown"] == "done"
     ctx.send_response.assert_called_once()
+    # single-stage workflow finished -> completion message
+    assert "Stage 1 of 1" in result
+    assert "complete" in result.lower()
+    assert "update_workflow_output" in result
+
+
+# --- #191: slug matching + clean error message -----------------------------
+
+
+async def test_update_workflow_stage_unknown_stage_message_has_no_dict_keys():
+    wf = _make_multistage_workflow()
+    registry = WorkflowRegistry()
+    agent_ref, _, _ = _multistage_agent_ref(wf)
+    result = await WorkflowRegistry.update_workflow_stage(
+        registry, stage_name="nonexistent", state="finished", results="r", agent=agent_ref,
+    )
+    assert "Stage name not found" in result
+    assert "dict_keys" not in result
+    assert "Collect METAR data" in result
+    assert "Assess flight conditions" in result
+
+
+async def test_update_workflow_stage_slug_match_resolves_variant():
+    wf = _make_multistage_workflow()
+    registry = WorkflowRegistry()
+    agent_ref, state, _ = _multistage_agent_ref(wf)
+    # differs in case/punctuation/whitespace from "Collect METAR data"
+    result = await WorkflowRegistry.update_workflow_stage(
+        registry,
+        stage_name=" Collect METAR-data ",
+        state="finished",
+        results="data collected",
+        agent=agent_ref,
+    )
+    assert "Stage name not found" not in result
+    # canonical key was the one mutated
+    assert state["progress"]["Collect METAR data"]["state"] == "finished"
+
+
+async def test_update_workflow_stage_slug_match_resolves_extra_spaces():
+    wf = _make_multistage_workflow()
+    registry = WorkflowRegistry()
+    agent_ref, state, _ = _multistage_agent_ref(wf)
+    # differs in case/punctuation/whitespace from "Collect METAR data"
+    result = await WorkflowRegistry.update_workflow_stage(
+        registry,
+        stage_name="Collect    METAR-data",
+        state="finished",
+        results="data collected",
+        agent=agent_ref,
+    )
+    assert "Stage name not found" not in result
+    # canonical key was the one mutated
+    assert state["progress"]["Collect METAR data"]["state"] == "finished"
+
+
+
+# --- #192: invariant enforcement -------------------------------------------
+
+
+async def test_update_workflow_stage_finished_blank_results_rejected():
+    wf = _make_multistage_workflow()
+    registry = WorkflowRegistry()
+    agent_ref, state, ctx = _multistage_agent_ref(wf)
+    result = await WorkflowRegistry.update_workflow_stage(
+        registry,
+        stage_name="Collect METAR data",
+        state="finished",
+        results="   ",
+        agent=agent_ref,
+    )
+    assert "not modified" in result
+    assert state["progress"]["Collect METAR data"] is None
+    ctx.send_response.assert_not_called()
+
+
+async def test_update_workflow_stage_in_progress_nonblank_results_rejected():
+    wf = _make_multistage_workflow()
+    registry = WorkflowRegistry()
+    agent_ref, state, ctx = _multistage_agent_ref(wf)
+    result = await WorkflowRegistry.update_workflow_stage(
+        registry,
+        stage_name="Collect METAR data",
+        state="in_progress",
+        results="some results",
+        agent=agent_ref,
+    )
+    assert "not modified" in result
+    assert state["progress"]["Collect METAR data"] is None
+    ctx.send_response.assert_not_called()
+
+
+async def test_update_workflow_stage_out_of_order_finish_warns_but_records():
+    wf = _make_multistage_workflow()
+    registry = WorkflowRegistry()
+    agent_ref, state, _ = _multistage_agent_ref(wf)
+    # finish the 2nd stage while the 1st is still unstarted
+    result = await WorkflowRegistry.update_workflow_stage(
+        registry,
+        stage_name="Assess flight conditions",
+        state="finished",
+        results="conditions ok",
+        agent=agent_ref,
+    )
+    assert state["progress"]["Assess flight conditions"]["state"] == "finished"
+    assert "Warning" in result
+    assert "Collect METAR data" in result
+
+
+# --- #190: cursor / re-grounding in the return value -----------------------
+
+
+async def test_update_workflow_stage_finished_nonfinal_names_next_stage_and_steps():
+    wf = _make_multistage_workflow()
+    registry = WorkflowRegistry()
+    agent_ref, _, _ = _multistage_agent_ref(wf)
+    result = await WorkflowRegistry.update_workflow_stage(
+        registry,
+        stage_name="Collect METAR data",
+        state="finished",
+        results="data",
+        agent=agent_ref,
+    )
+    assert "Stage 1 of 3" in result
+    assert 'Next stage: "Assess flight conditions"' in result
+    assert "evaluate ceilings" in result
+    assert "evaluate visibility" in result
+
+
+async def test_update_workflow_stage_finished_final_states_complete():
+    wf = _make_multistage_workflow()
+    registry = WorkflowRegistry()
+    agent_ref, _, _ = _multistage_agent_ref(wf)
+    await WorkflowRegistry.update_workflow_stage(
+        registry,
+        stage_name="Collect METAR data",
+        state="finished",
+        results="stage1",
+        agent=agent_ref,
+    )
+    await WorkflowRegistry.update_workflow_stage(
+        registry,
+        stage_name="Assess flight conditions",
+        state="finished",
+        results="stage2",
+        agent=agent_ref,
+    )
+    result = await WorkflowRegistry.update_workflow_stage(
+        registry,
+        stage_name="Summarize",
+        state="finished",
+        results="summary",
+        agent=agent_ref,
+    )
+    assert "Stage 3 of 3" in result
+    assert "complete" in result.lower()
+    assert "update_workflow_output" in result
+    assert "warning" not in result.lower()
+
+
+async def test_update_workflow_stage_finished_final_states_complete_with_skipped():
+    wf = _make_multistage_workflow()
+    registry = WorkflowRegistry()
+    agent_ref, _, _ = _multistage_agent_ref(wf)
+    result = await WorkflowRegistry.update_workflow_stage(
+        registry,
+        stage_name="Summarize",
+        state="finished",
+        results="summary",
+        agent=agent_ref,
+    )
+    assert "Stage 3 of 3" in result
+    assert "complete" in result.lower()
+    assert "update_workflow_output" in result
+    assert "warning" in result.lower()
+
+
+async def test_update_workflow_stage_in_progress_confirms_position():
+    wf = _make_multistage_workflow()
+    registry = WorkflowRegistry()
+    agent_ref, _, _ = _multistage_agent_ref(wf)
+    result = await WorkflowRegistry.update_workflow_stage(
+        registry,
+        stage_name="Assess flight conditions",
+        state="in_progress",
+        results="",
+        agent=agent_ref,
+    )
+    assert "Stage 2 of 3" in result
+    assert "in progress" in result.lower()
 
 
 # --- update_workflow_output ------------------------------------------------


### PR DESCRIPTION
Resolves issues #190, #191, #192

All three issues touch the same tool, WorkflowRegistry.update_workflow_stage, so they are addressed together.

instead of requiring an exact string, so case/punctuation/whitespace variants resolve to the canonical stage. Add a `collapse` option to slugify() so runs of whitespace/punctuation collapse to a single separator (existing callers keep the default and are unaffected). Replace the not-found error's raw dict_keys repr with a plain comma-separated list of stage names.

(with an instructive message, without mutating state) a 'finished' stage that has blank results and an 'in_progress' stage that carries results. When a stage is finished while earlier stages are still unstarted, record it but append a soft warning naming the skipped stages.

position (stage N of M); on finishing a non-final stage it names the next stage and lists its steps; on finishing the final stage it states the workflow is complete and reminds the agent to call update_workflow_output; on in_progress it confirms the active stage. Logic extracted into _build_stage_response.

Add unit tests covering slug resolution, the rejected invariant combinations (state left unmodified), out-of-order warnings, and the re-grounding output.