### PR TITLE
Compose workflow output from per-stage results instead of re-emitting (#195)

### DIFF
--- a/beaker-vue/src/components/panels/WorkflowOutputPanel.vue
+++ b/beaker-vue/src/components/panels/WorkflowOutputPanel.vue
@@ -3,31 +3,118 @@
         <p v-if="!attachedWorkflow">
             No workflow selected. Select one above or ask the agent about which workflow could work for your task.
         </p>
-        <div class="final-response p-steppanel" v-html="finalResponse" @click="handleImageClick">
-
-        </div>
+        <Tabs
+            v-else
+            v-model:value="activeTab"
+            class="workflow-output-tabs"
+        >
+            <TabList>
+                <Tab v-for="(stage, index) in stageViews" :key="stage.name" :value="index" :class="{ 'in-progress':  stage.state === 'in_progress'}">
+                    <span class="tab-label" :class="{ 'tab-label-pending': !stage.filled}">
+                        Stage {{ index + 1 }}
+                    </span>
+                    <ProgressSpinner
+                        v-if="stage.state === 'in_progress'"
+                        class="stage-pending-spinner"
+                        aria-label="Stage in progress"
+                    />
+                </Tab>
+                <Tab :key="'final-report'" :value="stageViews.length">
+                    <span class="tab-label" :class="{ 'tab-label-pending': !hasFinalReport }">
+                        Final Report
+                    </span>
+                </Tab>
+            </TabList>
+            <TabPanels>
+                <TabPanel v-for="(stage, index) in stageViews" :key="stage.name" :value="index">
+                    <div class="stage-section p-steppanel">
+                        <h3 class="stage-section-header">{{ stage.name }}</h3>
+                        <div
+                            v-if="stage.filled"
+                            class="stage-section-body"
+                            v-html="stage.html"
+                            @click="handleImageClick"
+                        ></div>
+                        <p v-else class="stage-pending">
+                            <span>{{ stage.state === 'in_progress' ? 'In progress…' : 'Not yet started.' }}</span>
+                        </p>
+                    </div>
+                </TabPanel>
+                <TabPanel :key="'final-report'" :value="stageViews.length">
+                    <div class="final-response p-steppanel" v-html="finalResponse" @click="handleImageClick">
+                    </div>
+                </TabPanel>
+            </TabPanels>
+        </Tabs>
     </div>
 </template>
 
 <script setup lang="ts">
-import { computed, inject, ref } from "vue";
+import { computed, inject, ref, watch } from "vue";
 import type { BeakerSessionComponentType } from '../session/BeakerSession.vue';
 import { useWorkflows } from '../../composables/useWorkflows';
 import { marked } from "marked";
+import Tabs from "primevue/tabs";
+import TabList from "primevue/tablist";
+import Tab from "primevue/tab";
+import TabPanels from "primevue/tabpanels";
+import TabPanel from "primevue/tabpanel";
+import ProgressSpinner from "primevue/progressspinner";
 import { ImageZoomDialog } from "../render";
 import { useDialog } from "primevue";
 
 const beakerSession = inject<BeakerSessionComponentType>("beakerSession");
-const { attachedWorkflow, attachedWorkflowFinalResponse } = useWorkflows(beakerSession);
+const { attachedWorkflow, attachedWorkflowProgress, attachedWorkflowFinalResponse } = useWorkflows(beakerSession);
+
+const activeTab = ref<number>(0);
+
+// Strip lines that are only pipes/whitespace — keeps malformed markdown tables from
+// rendering stray empty rows. Mirrors the cleanup the final report has always used.
+const renderMarkdown = (source: string): string => {
+    const cleaned = source.split('\n').filter(line => !line.match(/^[|\s]+$/)).join('\n');
+    return marked.parse(cleaned) as string;
+};
+
+const hasFinalReport = computed(() => Boolean(attachedWorkflowFinalResponse.value?.trim()));
+
+// One view-model per workflow stage, in definition order (matches the left panel's
+// stepper numbering). Tabs are pre-generated; `filled`/`html` populate as results arrive.
+const stageViews = computed(() => {
+    const progress = attachedWorkflowProgress.value ?? {};
+    return (attachedWorkflow.value?.stages ?? []).map((stage) => {
+        const entry = progress[stage.name];
+        const markdown = entry?.results_markdown ?? "";
+        const filled = Boolean(markdown.trim());
+        return {
+            name: stage.name,
+            state: entry?.state,
+            filled,
+            html: filled ? renderMarkdown(markdown) : "",
+        };
+    });
+});
 
 const finalResponse = computed(() => {
-    let response = `${attachedWorkflowFinalResponse.value}`;
-    if (response === "") {
-        response = "### No workflow output yet\nThis panel will be populated as the workflow stages complete."
+    let response = `${attachedWorkflowFinalResponse.value ?? ""}`;
+    if (response.trim() === "") {
+        response = "### No workflow output yet\nThis tab will show the final report once the workflow completes."
     }
-    response = response.split('\n').filter(line => !line.match(/^[|\s]+$/)).join('\n');
-    return marked.parse(response)
+    return renderMarkdown(response);
 })
+
+// Follow progress: jump to the Final Report once it arrives, otherwise to the latest
+// stage that has filled-in output. Falls back to the first stage before anything lands.
+watch([attachedWorkflowProgress, attachedWorkflowFinalResponse], () => {
+    if (hasFinalReport.value) {
+        activeTab.value = stageViews.value.length; // Final Report is the trailing tab.
+        return;
+    }
+    const latestFilled = stageViews.value.reduce(
+        (acc, stage, index) => (stage.filled ? index : acc),
+        -1,
+    );
+    activeTab.value = latestFilled >= 0 ? latestFilled : 0;
+}, { deep: true });
 
 const dialog = useDialog();
 const overlay = ref();
@@ -74,43 +161,98 @@ const handleImageClick = (event: MouseEvent) => {
 
 <style lang="scss">
 
-.final-response {
-    h1 { font-size: 1.3rem; }
-    h2 { font-size: 1.2rem; }
-    h3 { font-size: 1.10rem; }
-    h4 { font-size: 1.05rem; }
-    br,hr { width: 100%; }
-    padding: 0.5rem;
+.workflow-output-tabs {
+    // Pending (unfilled) stage tabs and the not-yet-ready Final Report tab read lighter
+    // than completed ones.
+    .p-tab {
+        display: flex;
+        align-items: end;
+        gap: 0.25rem;
 
-    table {
-        table-layout: fixed;
-        margin: 0 auto;
-        border-collapse: collapse;
-        border: 1px solid var(--p-datatable-body-cell-border-color);
-        tbody tr:nth-child(odd) {
-            background-color: var(--p-datatable-row-background);
+        &.in-progress {
+            padding-right: .25rem;
+            padding-left: 1rem;
         }
-        tbody tr:nth-child(odd) {
-            background-color: var(--p-datatable-row-striped-background);
+
+        .tab-label-pending {
+            opacity: 0.75;
+        }
+        &:not(.p-tab-active) .tab-label-pending {
+            color: var(--p-text-muted-color);
+        }
+
+        .stage-pending-spinner {
+            width: 1rem;
+            height: 1rem;
+            margin: 0;
+            opacity: 1;
         }
     }
 
-    th,
-    td {
-        padding: 0.2rem;
-        border: 1px solid var(--p-datatable-body-cell-border-color);
+    // Shared markdown styling for both the per-stage views and the final report.
+    .final-response,
+    .stage-section-body {
+        h1 { font-size: 1.3rem; }
+        h2 { font-size: 1.2rem; }
+        h3 { font-size: 1.10rem; }
+        h4 { font-size: 1.05rem; }
+        br,hr { width: 100%; }
+
+        table {
+            table-layout: fixed;
+            margin: 0 auto;
+            border-collapse: collapse;
+            border: 1px solid var(--p-datatable-body-cell-border-color);
+            tbody tr:nth-child(odd) {
+                background-color: var(--p-datatable-row-background);
+            }
+            tbody tr:nth-child(odd) {
+                background-color: var(--p-datatable-row-striped-background);
+            }
+        }
+
+        th,
+        td {
+            padding: 0.2rem;
+            border: 1px solid var(--p-datatable-body-cell-border-color);
+        }
+
+        img {
+            border-radius: 0.25rem;
+            max-width: 100%;
+            cursor: pointer;
+            transition: box-shadow 0.6s ease;
+            padding: 1px;
+
+            &:hover {
+                box-sizing: border-box;
+                box-shadow: inset 0 0 0 1px var(--p-surface-500);
+            }
+        }
     }
 
-    img {
-        border-radius: 0.25rem;
-        max-width: 100%;
-        cursor: pointer;
-        transition: box-shadow 0.6s ease;
-        padding: 1px;
+    .final-response,
+    .stage-section {
+        padding: 0.5rem;
+    }
 
-        &:hover {
-            box-sizing: border-box;
-            box-shadow: inset 0 0 0 1px var(--p-surface-500);
+    .stage-section-header {
+        font-size: 1.5rem;
+        font-weight: bold;
+        text-decoration: underline;
+        margin: 0 0 0.5rem 0;
+    }
+
+    .stage-pending {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        color: var(--p-text-muted-color);
+
+        .stage-pending-spinner {
+            width: 1.25rem;
+            height: 1.25rem;
+            margin: 0;
         }
     }
 }

--- a/src/beaker_notebook/lib/workflow.py
+++ b/src/beaker_notebook/lib/workflow.py
@@ -19,20 +19,28 @@ is ACTIVE at a time.
 For each stage, in order:
 1. Perform every step in sequence. Never substitute assumed or example data
    for missing data — stop and ask the user.
-2. Call `update_workflow_output` with the cumulative results so far, formatted
-   per the active workflow's `<workflow-result-formatting-instructions>`.
-3. Call `ask_user` (format: `workflow-confirmation`) to confirm before continuing.
-4. Resolve the response:
+2. Call `ask_user` (format: `workflow-confirmation`) to confirm before continuing.
+3. Resolve the response:
    - "continue" or `ask_user` times out: call `update_workflow_stage` with
-     state="finished" and the stage's results in markdown. If the user
-     confirmed, call `update_workflow_stage` for the next stage with
+     state="finished" and the stage's results in markdown. Emit each stage's
+     results exactly once, here — do not re-emit earlier stages' results. If the
+     user confirmed, call `update_workflow_stage` for the next stage with
      state="in_progress" and begin its steps. If `ask_user` timed out, stop
      and wait for the user to message to resume.
    - "cancel": stop. The workflow may be resumed later.
    - anything else: treat as a normal user request; it takes precedence over
      advancing the workflow. If handling it changes a stage's results, redo
-     the affected work and call `update_workflow_stage` and
-     `update_workflow_output` again with the new values.
+     the affected work and call `update_workflow_stage` again with the new
+     values. Only call `update_workflow_output` again if the workflow has
+     already completed — otherwise the final assembly step below picks up the
+     corrected results.
+
+When every stage is finished, assemble the final output once: call
+`update_workflow_output` with the complete report for all stages, formatted per
+the active workflow's `<workflow-result-formatting-instructions>`. Do this a
+single time, at the end. The per-stage results you already emitted via
+`update_workflow_stage` are retained and shown to the user as the workflow runs,
+so there is no need to re-emit cumulative output between stages.
 
 ## Selecting a workflow
 
@@ -394,7 +402,8 @@ class WorkflowRegistry(Mapping[str, Workflow]):
             if next_key is None:
                 lines.append(
                     "The workflow is now complete. Call `update_workflow_output` "
-                    "with the cumulative results for the entire workflow."
+                    "once with the complete report for all stages, formatted per the "
+                    "workflow's `<workflow-result-formatting-instructions>`."
                 )
             else:
                 next_position = f"Stage {index + 2} of {total}"
@@ -419,8 +428,11 @@ class WorkflowRegistry(Mapping[str, Workflow]):
         """
         Updates the overall output of the workflow.
 
-        This tool must be called whenever a workflow stage completes, or whenever
-        redoing a task would impact the "final output" of a workflow.
+        Call this tool once, after the final stage of the workflow finishes, to
+        assemble the complete report. Call it again only if a change made after the
+        workflow has already completed alters the final output. Do not call it
+        between stages — per-stage results are emitted via `update_workflow_stage`
+        and shown to the user as the workflow runs.
 
         The final output of the workflow must be formatted according to the
         `<workflow-result-formatting-instructions></workflow-result-formatting-instructions>`


### PR DESCRIPTION
The workflow preamble instructed the agent to call `update_workflow_output` with the full cumulative report after every stage. This burned tokens quadratically in the number of stages and caused earlier stages' content to drift or truncate as later re-emissions summarized what earlier ones stated in full.

Each stage's result already lives in `WorkflowState.progress[stage] .results_markdown`, emitted once via `update_workflow_stage`. Stop re-deriving the cumulative report between stages and assemble the final formatted report exactly once, at the end. `final_response` remains the agent's single synthesis/formatting pass per the workflow's result-formatting instructions — not a mechanical concatenation.

Backend (lib/workflow.py):
- Drop the per-stage `update_workflow_output` step from the preamble; add a single end-of-workflow assembly instruction. Scope the redo-branch re-call to post-completion changes only.
- Update the `update_workflow_output` docstring and the stage-completion message to reflect the once-at-the-end contract.

Frontend (WorkflowOutputPanel.vue):
- Replace the single final_response view with one tab per stage (labeled to match the left panel's stepper) plus a Final Report tab.
- Compose each stage tab from progress[stage].results_markdown, ordered by the workflow's stage list rather than progress-key insertion order.
- Auto-follow to the latest filled stage during the run and to Final Report when it arrives; show pending/in-progress affordances on unfilled tabs.
- Use the current PrimeVue Tabs API (not deprecated TabView).

Wire format and WorkflowState shape are unchanged; no migration needed.