### PR TITLE
Workflow module hygiene sweep (#196)

### DIFF
--- a/beaker-vue/src/components/misc/WorkflowSelectDialog.vue
+++ b/beaker-vue/src/components/misc/WorkflowSelectDialog.vue
@@ -181,13 +181,16 @@ const searchResults = computed<{[key in string]: any}>(() => {
     if (!workflows.value) return {};
     return Object.fromEntries(
         Object.entries(workflows.value).filter(([_, workflow]) =>
-            searchText.value === ""
+            // Hidden workflows are never offered in the picker; they remain
+            // attachable by id (e.g. a context default) and render fine if attached.
+            !workflow.hidden
+            && (searchText.value === ""
             || searchText.value === undefined
             || [
                 workflow.human_description,
                 workflow.title,
                 workflow.category
-            ].join(' ').toLocaleLowerCase().includes(searchText.value.toLocaleLowerCase()))
+            ].join(' ').toLocaleLowerCase().includes(searchText.value.toLocaleLowerCase())))
     );
 });
 

--- a/beaker-vue/src/composables/useWorkflows.ts
+++ b/beaker-vue/src/composables/useWorkflows.ts
@@ -32,7 +32,6 @@ interface UseWorkflowsReturn {
     attachedWorkflowId: ComputedRef<string | undefined>;
     attachedWorkflow: ComputedRef<BeakerWorkflow | undefined>;
     attachedWorkflowProgress: ComputedRef<{[key: string]: {
-        code_cell_id: string,
         state: 'in_progress' | 'finished',
         results_markdown: string
     }} | undefined>;

--- a/src/beaker_notebook/lib/context.py
+++ b/src/beaker_notebook/lib/context.py
@@ -580,7 +580,7 @@ class BeakerContext:
             agent_details = None
 
         workflow_info = {
-            "state": self.current_workflow_state,
+            "state": asdict(self.current_workflow_state) if self.current_workflow_state is not None else None,
             "workflows": {
                 uuid: asdict(workflow)
                 for uuid, workflow in self.workflows.items()
@@ -844,14 +844,20 @@ class BeakerContext:
 
     @property
     def attached_workflow(self) -> Workflow | None:
-        return self.workflows.get(self.current_workflow_state["workflow_id"], None) if self.current_workflow_state else None
+        return self.workflows.get(self.current_workflow_state.workflow_id, None) if self.current_workflow_state else None
 
     def attach_workflow(self, workflow: Workflow | None):
         if workflow is None:
             self.current_workflow_state = None
         else:
             self.current_workflow_state = WorkflowState.from_workflow(workflow)
-        self.send_response("iopub", "update_workflow_state", self.current_workflow_state)
+        self.send_workflow_state()
+
+    def send_workflow_state(self):
+        state = self.current_workflow_state
+        if dataclasses.is_dataclass(state):
+            state = dataclasses.asdict(state)
+        self.send_response("iopub", "update_workflow_state", state)
 
     @action()
     async def set_workflow(self, message):

--- a/src/beaker_notebook/lib/workflow.py
+++ b/src/beaker_notebook/lib/workflow.py
@@ -1,7 +1,7 @@
 from archytas.tool_utils import tool, statetool, AgentRef
 from collections.abc import Mapping
-from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Iterator, Literal, Optional, Any, TypedDict
+from dataclasses import dataclass, field, asdict
+from typing import TYPE_CHECKING, Iterator, Literal, Optional, Any
 
 from beaker_notebook.lib.utils import slugify
 
@@ -105,6 +105,12 @@ class Workflow:
     example_prompt: str
     stages: list[WorkflowStage]
 
+    # When true, the workflow is not surfaced proactively: it is excluded from
+    # both the agent's workflow synopsis (see create_available_workflows_prompt
+    # below) and the UI picker (filtered in beaker-vue's WorkflowSelectDialog.vue,
+    # since the full set is still shipped to the client as a by-id lookup table).
+    # It remains attachable by explicit id -- e.g. as a context default
+    # (is_context_default) or via a programmatic attach.
     hidden: Optional[bool] = field(default=False)
     is_context_default: Optional[bool] = field(default=False)
     category: Optional[str] = field(default=None)
@@ -117,6 +123,28 @@ class Workflow:
         self.title = self.title.strip()
         if not self.id:
             self.id = slugify(self.title)
+
+        # Normalize hidden to a real bool: from_yaml passes None when the key is
+        # absent, and downstream filters test it directly.
+        self.hidden = bool(self.hidden)
+
+        # Reject duplicate stage names. Progress is keyed by stage name and
+        # `update_workflow_stage` matches the agent's input via
+        # slugify(..., collapse=True); names that are equal -- or merely
+        # slug-equal (differ only in case/punctuation/whitespace) -- would
+        # collapse into a single progress slot. Detect collisions on the slug so
+        # those variants are caught too, and fail load with a clear message
+        # (discovery turns this into a per-file skip).
+        seen: dict[str, str] = {}
+        for stage in self.stages:
+            key = slugify(stage.name, collapse=True)
+            if key in seen:
+                raise ValueError(
+                    f"Workflow {self.title!r} has a duplicate stage name "
+                    f"{stage.name!r} (collides with {seen[key]!r}); stage names "
+                    "must be unique."
+                )
+            seen[key] = stage.name
 
     @staticmethod
     def from_yaml(source: dict[str, Any]) -> "Workflow":
@@ -178,19 +206,20 @@ class Workflow:
         return "\n".join(prompt_parts)
 
 
-class WorkflowStageProgress(TypedDict):
+@dataclass(kw_only=True)
+class WorkflowStageProgress:
     state: Literal['in_progress', 'finished']
-    code_cell_id: str
     results_markdown: str
 
 
-class WorkflowState(TypedDict):
+@dataclass(kw_only=True)
+class WorkflowState:
     workflow_id: str
     progress: dict[str, WorkflowStageProgress | None]
     final_response: str
 
     @classmethod
-    def from_workflow(cls, workflow: Workflow) -> "WorkflowState": # type: ignore
+    def from_workflow(cls, workflow: Workflow) -> "WorkflowState":
         return cls(
             workflow_id=workflow.id,
             progress={
@@ -207,6 +236,9 @@ def create_available_workflows_prompt(
     """
     Create a fully rendered prompt for the context based on a list of workflows and which,
     if any, of them is active.
+
+    Hidden workflows are omitted from the synopsis so the agent does not surface
+    them proactively; they remain attachable by explicit id.
     """
     workflow_synopsis = "\n\n".join([
         f"""<workflow>
@@ -215,6 +247,7 @@ def create_available_workflows_prompt(
     <description>{workflow.agent_description}</description>
 </workflow>"""
         for workflow in workflows
+        if not workflow.hidden
     ])
 
     return WORKFLOW_PREAMBLE_PROMPT.format(
@@ -291,7 +324,7 @@ class WorkflowRegistry(Mapping[str, Workflow]):
                 return f"Failed to find workflow with id `{workflow_id}`. Existing workflows: `{(list(self.keys()))!r}`: invalid tool input."
 
         agent.context.attach_workflow(workflow)
-        agent.context.send_response("iopub", "update_workflow_state", agent.context.current_workflow_state)
+        agent.context.send_workflow_state()
         return f'Successfully set the attached workflow to "{workflow.title}" ({workflow.id}).'
 
     @tool(internal=True)
@@ -326,7 +359,7 @@ class WorkflowRegistry(Mapping[str, Workflow]):
             return "State must be one of `in_progress` or `finished`."
 
         # Resolve the agent's input to the canonical stored stage key via slugify on both sides.
-        progress = agent.context.current_workflow_state["progress"]
+        progress = agent.context.current_workflow_state.progress
         resolved_key = None
         desired = slugify(stage_name, collapse=True)
         for key in progress:
@@ -359,12 +392,11 @@ class WorkflowRegistry(Mapping[str, Workflow]):
                     skipped_stages.append(key)
 
         progress[resolved_key] = WorkflowStageProgress(
-            code_cell_id='',
             state=state,
             results_markdown=results,
         )
 
-        agent.context.send_response("iopub", "update_workflow_state", agent.context.current_workflow_state)
+        agent.context.send_workflow_state()
 
         return self._build_stage_response(agent, resolved_key, state, skipped_stages)
 
@@ -380,7 +412,7 @@ class WorkflowRegistry(Mapping[str, Workflow]):
         Re-grounds the agent at every transition: its position (`N of M`), and,
         when finishing a non-final stage, the next stage's name and steps.
         """
-        progress_keys = list(agent.context.current_workflow_state["progress"].keys())
+        progress_keys = list(agent.context.current_workflow_state.progress.keys())
         total = len(progress_keys)
         index = progress_keys.index(resolved_key)  # zero-based
         position = f"Stage {index + 1} of {total}"
@@ -447,8 +479,8 @@ class WorkflowRegistry(Mapping[str, Workflow]):
         Returns:
             str: Information about the operation.
         """
-        agent.context.current_workflow_state["final_response"] = results
-        agent.context.send_response("iopub", "update_workflow_state", agent.context.current_workflow_state)
+        agent.context.current_workflow_state.final_response = results
+        agent.context.send_workflow_state()
         return "Successfully set workflow output."
 
 

--- a/tests/workflows/test_discover_workflows.py
+++ b/tests/workflows/test_discover_workflows.py
@@ -6,6 +6,7 @@ auto-attach of a default workflow.
 """
 
 import logging
+from dataclasses import asdict
 from unittest.mock import MagicMock
 
 from beaker_notebook.lib.context import BeakerContext
@@ -160,13 +161,13 @@ def test_default_workflow_attached_during_init(tmp_path):
     ctx = ctx_cls(beaker_kernel=kernel)
 
     assert ctx.current_workflow_state is not None
-    assert ctx.current_workflow_state["workflow_id"] == slugify("Build Pipeline")
+    assert ctx.current_workflow_state.workflow_id == slugify("Build Pipeline")
     # The attach went through send_response on the (already-wired) kernel.
     # send_response forwards extra positional args (channel, parent_header, ...),
     # so match only the leading (stream, msg_type, content) triple.
     assert any(
         call.args[:3]
-        == ("iopub", "update_workflow_state", ctx.current_workflow_state)
+        == ("iopub", "update_workflow_state", asdict(ctx.current_workflow_state))
         for call in kernel.send_response.call_args_list
     )
 

--- a/tests/workflows/test_workflow_creation.py
+++ b/tests/workflows/test_workflow_creation.py
@@ -1,0 +1,130 @@
+"""Tests for workflow construction/loading validation (lib/workflow.py).
+
+Covers issue #196 item 3: a workflow whose stages contain duplicate names must
+fail to load with a clear message rather than silently collapsing two stages
+into one progress slot.
+
+`WorkflowState.from_workflow` keys progress by stage name, and
+`update_workflow_stage` resolves the agent's input to a stored key via
+`slugify(name, collapse=True)`. So two stages whose names are equal — or merely
+slug-equal (differ only in case/punctuation/whitespace) — would share a single
+progress entry. Rejection therefore happens at load, in `Workflow.from_yaml`,
+and discovery's existing per-file skip path (see
+`test_discover_workflows.test_discover_skips_broken_and_loads_valid`) carries it
+the rest of the way: a raising `from_yaml` causes the file to be skipped with a
+warning naming it.
+"""
+
+import logging
+
+import pytest
+
+from beaker_notebook.lib.context import BeakerContext
+from beaker_notebook.lib.workflow import Workflow
+
+
+def _source_with_stages(stage_names: list[str], title: str = "Build Pipeline") -> dict:
+    """A minimal, otherwise-valid `from_yaml` source with the given stage names."""
+    return {
+        "title": title,
+        "agent_description": "agent desc",
+        "human_description": "human desc",
+        "example_prompt": "example",
+        "stages": [
+            {"name": name, "steps": [{"prompt": "do thing"}]}
+            for name in stage_names
+        ],
+    }
+
+
+def _yaml_with_stages(stage_names: list[str], title: str = "Build Pipeline") -> str:
+    lines = [
+        f"title: {title}",
+        "agent_description: agent desc",
+        "human_description: human desc",
+        "example_prompt: example",
+        "stages:",
+    ]
+    for name in stage_names:
+        lines += [
+            f"  - name: {name}",
+            "    steps:",
+            "      - prompt: do thing",
+        ]
+    return "\n".join(lines) + "\n"
+
+
+def _make_context_class(workflow_dir):
+    class _TestContext(BeakerContext):
+        workflow_location = str(workflow_dir)
+
+    return _TestContext
+
+
+# --- from_yaml validation --------------------------------------------------
+
+
+def test_distinct_stage_names_load_fine():
+    """Positive control: a workflow with distinct stage names still parses."""
+    wf = Workflow.from_yaml(_source_with_stages(["collect", "assess", "summarize"]))
+    assert [stage.name for stage in wf.stages] == ["collect", "assess", "summarize"]
+
+
+def test_exact_duplicate_stage_names_rejected():
+    source = _source_with_stages(["collect", "summarize", "collect"])
+    with pytest.raises(ValueError) as excinfo:
+        Workflow.from_yaml(source)
+    # A clear message that names the offending stage.
+    assert "collect" in str(excinfo.value)
+    assert "duplicate" in str(excinfo.value).lower()
+
+
+def test_slug_variant_duplicate_stage_names_rejected():
+    """Design decision: "duplicate" is defined by slug-equality, not exact
+    string equality, because `update_workflow_stage` matches stage names via
+    `slugify(..., collapse=True)`. "Collect Data" and "collect  data" resolve to
+    the same progress slot, so they must be rejected at load too.
+
+    If we ever decide duplicates should be exact-match only, this test is the one
+    to flip.
+    """
+    source = _source_with_stages(["Collect Data", "collect  data"])
+    with pytest.raises(ValueError) as excinfo:
+        Workflow.from_yaml(source)
+    assert "duplicate" in str(excinfo.value).lower()
+
+
+# --- hidden normalization (#196 item 2) ------------------------------------
+
+
+def test_hidden_defaults_to_false_when_absent():
+    # from_yaml passes source.get("hidden", None); __post_init__ normalizes it.
+    wf = Workflow.from_yaml(_source_with_stages(["collect"]))
+    assert wf.hidden is False
+
+
+def test_hidden_true_is_preserved():
+    source = _source_with_stages(["collect"])
+    source["hidden"] = True
+    wf = Workflow.from_yaml(source)
+    assert wf.hidden is True
+
+
+# --- discovery skips a duplicate-stage workflow ----------------------------
+
+
+def test_discover_skips_workflow_with_duplicate_stage_names(tmp_path, caplog):
+    (tmp_path / "good.yaml").write_text(_yaml_with_stages(["collect", "summarize"]))
+    (tmp_path / "dupe.yaml").write_text(
+        _yaml_with_stages(["collect", "collect"], title="Dupe Stages")
+    )
+
+    ctx_cls = _make_context_class(tmp_path)
+    with caplog.at_level(logging.WARNING):
+        result = ctx_cls.discover_workflows()
+
+    assert len(result) == 1
+    titles = {wf.title for wf in result.values()}
+    assert titles == {"Build Pipeline"}
+    # Skipped with a warning naming the offending file (existing skip path).
+    assert any("dupe.yaml" in rec.message for rec in caplog.records)

--- a/tests/workflows/test_workflow_tools.py
+++ b/tests/workflows/test_workflow_tools.py
@@ -1,5 +1,7 @@
 """Tests for tools on WorkflowRegistry (lib/workflow.py)."""
 
+import json
+from functools import partial
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -10,13 +12,35 @@ from beaker_notebook.lib.workflow import (
     WorkflowRegistry,
     WorkflowStage,
     WorkflowStep,
+    WorkflowState,
     WorkflowStageProgress,
     create_available_workflows_prompt,
     workflow_condition,
 )
 
 
-def _make_workflow(title: str = "Build Pipeline", id: str = None, agent_instructions: str | None = None) -> Workflow:
+def _make_context(workflows, state, attached, *kwargs) -> SimpleNamespace:
+    from beaker_notebook.lib.context import BeakerContext
+
+    ns = SimpleNamespace(
+        workflows=workflows,
+        current_workflow_state=state,
+        attached_workflow=attached,
+        attach_workflow=MagicMock(),
+        send_response=MagicMock(),
+        send_workflow_state=None,
+    )
+    ns.send_workflow_state = partial(BeakerContext.send_workflow_state, ns)
+
+    return ns
+
+
+def _make_workflow(
+    title: str = "Build Pipeline",
+    id: str = None,
+    agent_instructions: str | None = None,
+    hidden: bool = False,
+) -> Workflow:
     return Workflow(
         title=title,
         id=id,
@@ -31,6 +55,7 @@ def _make_workflow(title: str = "Build Pipeline", id: str = None, agent_instruct
             )
         ],
         agent_instructions=agent_instructions,
+        hidden=hidden,
     )
 
 
@@ -41,18 +66,12 @@ def _make_agent_ref(
 ):
     if progress is None:
         progress = {"stage_one": None}
-    state = {
-        "workflow_id": "wf-uuid",
-        "progress": progress,
-        "final_response": "",
-    }
-    context = SimpleNamespace(
-        workflows=workflows,
-        current_workflow_state=state,
-        attached_workflow=attached,
-        attach_workflow=MagicMock(),
-        send_response=MagicMock(),
+    state = WorkflowState(
+        workflow_id="wf-uuid",
+        progress=progress,
+        final_response="",
     )
+    context = _make_context(workflows, state, attached)
     return SimpleNamespace(context=context), state, context
 
 
@@ -168,9 +187,9 @@ async def test_update_workflow_stage_writes_progress():
     result = await WorkflowRegistry.update_workflow_stage(
         registry, stage_name="stage_one", state="finished", results="done", agent=agent_ref,
     )
-    progress = state["progress"]["stage_one"]
-    assert progress["state"] == "finished"
-    assert progress["results_markdown"] == "done"
+    progress = state.progress["stage_one"]
+    assert progress.state == "finished"
+    assert progress.results_markdown == "done"
     ctx.send_response.assert_called_once()
     # single-stage workflow finished -> completion message
     assert "Stage 1 of 1" in result
@@ -208,7 +227,7 @@ async def test_update_workflow_stage_slug_match_resolves_variant():
     )
     assert "Stage name not found" not in result
     # canonical key was the one mutated
-    assert state["progress"]["Collect METAR data"]["state"] == "finished"
+    assert state.progress["Collect METAR data"].state == "finished"
 
 
 async def test_update_workflow_stage_slug_match_resolves_extra_spaces():
@@ -225,7 +244,7 @@ async def test_update_workflow_stage_slug_match_resolves_extra_spaces():
     )
     assert "Stage name not found" not in result
     # canonical key was the one mutated
-    assert state["progress"]["Collect METAR data"]["state"] == "finished"
+    assert state.progress["Collect METAR data"].state == "finished"
 
 
 
@@ -244,7 +263,7 @@ async def test_update_workflow_stage_finished_blank_results_rejected():
         agent=agent_ref,
     )
     assert "not modified" in result
-    assert state["progress"]["Collect METAR data"] is None
+    assert state.progress["Collect METAR data"] is None
     ctx.send_response.assert_not_called()
 
 
@@ -260,7 +279,7 @@ async def test_update_workflow_stage_in_progress_nonblank_results_rejected():
         agent=agent_ref,
     )
     assert "not modified" in result
-    assert state["progress"]["Collect METAR data"] is None
+    assert state.progress["Collect METAR data"] is None
     ctx.send_response.assert_not_called()
 
 
@@ -276,7 +295,7 @@ async def test_update_workflow_stage_out_of_order_finish_warns_but_records():
         results="conditions ok",
         agent=agent_ref,
     )
-    assert state["progress"]["Assess flight conditions"]["state"] == "finished"
+    assert state.progress["Assess flight conditions"].state == "finished"
     assert "Warning" in result
     assert "Collect METAR data" in result
 
@@ -374,7 +393,7 @@ async def test_update_workflow_output_sets_final_response():
         registry, results="# Final report", agent=agent_ref,
     )
     assert "Successfully" in result
-    assert state["final_response"] == "# Final report"
+    assert state.final_response == "# Final report"
     ctx.send_response.assert_called_once()
 
 
@@ -501,3 +520,108 @@ def test_agent_instructions_only_appear_after_selection():
     agent_ref, _, _ = _make_agent_ref(workflows={"u1": wf}, attached=wf)
     attached_state = WorkflowRegistry.attached_workflow_state(registry, agent=agent_ref)
     assert AGENT_INSTRUCTIONS in attached_state
+
+
+# --- #196: WorkflowState must survive the wire as a dataclass --------------
+#
+# WorkflowState / WorkflowStageProgress moved from TypedDict to dataclass. The
+# emit sites hand the state to send_response, whose real serialization is a bare
+# json.dumps with no dataclass fallback. These tests use a send_response that
+# reproduces that serialization, so they FAIL (TypeError) until the state is
+# converted to a plain dict (e.g. asdict / to_dict) at each emit site, and they
+# also pin the wire shape — including the removal of the dead `code_cell_id`.
+
+
+async def test_update_workflow_stage_emits_wire_serializable_state():
+    wf = _make_workflow()
+    registry = WorkflowRegistry()
+    agent_ref, state, context = _make_agent_ref(
+        workflows={"u1": wf}, attached=wf,
+    )
+    await WorkflowRegistry.update_workflow_stage(
+        registry, stage_name="stage_one", state="finished", results="done", agent=agent_ref,
+    )
+    assert context.send_response.call_count == 1
+    _, msg_type, payload = context.send_response.call_args.args
+    assert msg_type == "update_workflow_state"
+    assert payload["workflow_id"] == "wf-uuid"
+    assert payload["final_response"] == ""
+    stage = payload["progress"]["stage_one"]
+    assert stage["state"] == "finished"
+    assert stage["results_markdown"] == "done"
+    # Dead field removed (#196 item 1): it must not reappear on the wire.
+    assert "code_cell_id" not in stage
+
+
+async def test_update_workflow_output_emits_wire_serializable_state():
+    registry = WorkflowRegistry()
+    agent_ref, state, context = _make_agent_ref(workflows={})
+    await WorkflowRegistry.update_workflow_output(
+        registry, results="# Final report", agent=agent_ref,
+    )
+    assert context.send_response.call_count == 1
+    _, msg_type, payload = context.send_response.call_args.args
+    assert msg_type == "update_workflow_state"
+    assert payload["final_response"] == "# Final report"
+
+
+async def test_attach_workflow_emits_wire_serializable_state():
+    wf = _make_workflow("Build Pipeline")
+    workflow_id = wf.id
+    registry = WorkflowRegistry({workflow_id: wf})
+    agent_ref, state, context = _make_agent_ref(workflows=registry)
+
+    await WorkflowRegistry.attach_workflow.run(
+        args={"workflow_id": workflow_id, "agent": agent_ref},
+        tool_context={"agent": agent_ref},
+        self_ref=registry,
+    )
+    assert context.send_response.call_count == 1
+    _, msg_type, payload = context.send_response.call_args.args
+    assert msg_type == "update_workflow_state"
+    assert payload["workflow_id"] == "wf-uuid"
+    assert "progress" in payload
+    assert "final_response" in payload
+
+
+# --- #196 item 2: hidden workflows are not surfaced to the agent -----------
+#
+# `hidden: true` means "not surfaced proactively." For the agent that means the
+# workflow is omitted from the synopsis (create_available_workflows_prompt /
+# system_preamble); it stays attachable by id. (The UI half of this -- the
+# picker -- is enforced in WorkflowSelectDialog.vue.)
+
+
+def test_hidden_workflow_excluded_from_synopsis():
+    visible = _make_workflow("Visible Flow")
+    hidden = _make_workflow("Hidden Flow", hidden=True)
+    prompt = create_available_workflows_prompt([visible, hidden])
+    assert "Visible Flow" in prompt
+    assert visible.id in prompt
+    assert "Hidden Flow" not in prompt
+    assert hidden.id not in prompt
+
+
+async def test_hidden_workflow_excluded_from_system_preamble():
+    visible = _make_workflow("Visible Flow")
+    hidden = _make_workflow("Hidden Flow", hidden=True)
+    registry = WorkflowRegistry({visible.id: visible, hidden.id: hidden})
+    preamble = await registry.system_preamble()
+    assert preamble is not None
+    assert "Visible Flow" in preamble
+    assert "Hidden Flow" not in preamble
+
+
+async def test_hidden_workflow_still_attachable_by_id():
+    """Hidden only suppresses proactive surfacing; explicit attach still works."""
+    hidden = _make_workflow("Hidden Flow", hidden=True)
+    registry = WorkflowRegistry({hidden.id: hidden})
+    agent_ref, _, ctx = _make_agent_ref(workflows=registry)
+
+    result = await WorkflowRegistry.attach_workflow.run(
+        args={"workflow_id": hidden.id, "agent": agent_ref},
+        tool_context={"agent": agent_ref},
+        self_ref=registry,
+    )
+    assert "Successfully" in result
+    ctx.attach_workflow.assert_called_once_with(hidden)


### PR DESCRIPTION
Tighten up the workflow module: remove dead state, enforce "hidden" semantics, validate stage names at load, and replace the wire-state TypedDicts with dataclasses.

- Remove the unused WorkflowStageProgress.code_cell_id field (always '' and never read) from both the Python type and the TS interface.

- Enforce "hidden" semantics. Normalize `hidden` to a real bool in __post_init__ (from_yaml passes None when the key is absent) and exclude hidden workflows from the agent synopsis
(create_available_workflows_prompt) and the UI picker (WorkflowSelectDialog.vue). Hidden workflows remain attachable by id, e.g. as a context default. Documented the split where the field is defined.

- Reject duplicate stage names at load with a clear ValueError. Progress is keyed by stage name, so collisions (including slug variants) would silently clobber state.

- Convert WorkflowState and WorkflowStageProgress from TypedDict to dataclasses and serialize via dataclasses.asdict() in a new send_workflow_state() helper, preserving the existing wire shape while dropping the type: ignore workarounds.

- Reorganize workflow tests under tests/workflows/ and add coverage for hidden filtering, duplicate-stage rejection, and wire serializability.