### PR TITLE
Round-trippable Beaker chat-history serialization (resolves #224)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "archytas>=2.0.0",
+  "archytas>=2.0.2",
   "jupyterlab~=4.0",
   "jupyterlab-server>=2.22.1,<3",
   "requests>=2.24,<3",

--- a/src/beaker_notebook/lib/chat_history.py
+++ b/src/beaker_notebook/lib/chat_history.py
@@ -1,0 +1,507 @@
+"""Beaker-specific, round-trippable serialization envelope for agent chat history.
+
+This module defines :class:`BeakerChatHistoryDoc`, a versioned envelope that
+wraps an Archytas :class:`~archytas.chat_history.ChatHistory` for inclusion in a
+saved notebook. It adds two things on top of the Archytas serde:
+
+  * A Beaker *envelope* schema (:data:`BEAKER_CHAT_HISTORY_SCHEMA`), versioned
+    independently of the Archytas envelope it carries, reified via the same
+    :class:`~archytas.chat_history.SerdeSchema` mechanism so the format can be
+    inspected, compared, and versioned. A change to the Beaker envelope
+    (metadata block, compression) bumps this schema; Archytas message/record
+    drift bumps the Archytas schemas instead.
+  * An optional *cell-link* overlay (:data:`CELL_LINKS_SCHEMA`, versioned on its
+    own so the link shape can drift independently of the envelope) mapping
+    chat-history record ``uuid``s to the notebook cell(s) they produced. The
+    overlay is advisory only: a missing, partial, or stale mapping never
+    prevents the history from being reconstructed, so the history stays fully
+    functional when notebook cells drift (deleted, edited, reordered, or never
+    matched). Full message bodies are always retained -- cell links are an
+    overlay, not a storage dependency, so there is no dedupe-by-reference.
+
+The link value is a small tagged union keyed by message kind, because the
+record types map to cells differently:
+
+  * ``human`` -- the ReAct-loop-initiating ``HumanMessage``; maps to one query
+    cell.
+  * ``ai`` -- an ``AIMessage`` carrying a thought plus tool calls; maps to an
+    optional thought cell and, per tool call, zero-or-more cells (a list, so a
+    single tool call that emits several cells is representable).
+  * ``tool`` -- a ``ToolMessage`` (a tool result); maps to zero-or-more cells
+    for its one tool call.
+
+Cardinality is encoded by the ``cells`` lists, so no per-tool schema variants
+are needed: ``run_code`` happens to be one code cell today, but a tool that
+emits several cells, or none, fits the same shape. Within a ``cells`` list,
+presence vs. absence is meaningful for drift diagnosis: a tool call that
+*should* have a cell but could not be matched carries an empty ``cells`` list,
+whereas a non-cell-bearing tool call is simply omitted from ``tool_calls``.
+
+On save, the agent's ``system_message`` and ``system_preamble`` are
+intentionally dropped from the wrapped Archytas payload: both are regenerated
+from the agent/context at load time, so persisting a snapshot would only risk
+staleness. The ``user_preamble`` is retained -- it can carry user-authored text
+that cannot be regenerated. (Archytas serializes all three faithfully; the
+omission is Beaker's load-policy choice, applied here.)
+
+The inner Archytas history payload may optionally be stored as base64-encoded
+gzip to keep large histories compact; the envelope (schema, metadata, cell
+links) is always left in cleartext so the document remains inspectable without
+decompression.
+
+Scope: this module handles the *format* only. Computing cell links from a live
+notebook and wiring save/load/rehydration into the notebook file are handled
+elsewhere (see beaker-notebook#225).
+"""
+
+import base64
+import copy
+import gzip
+import json
+import warnings
+from dataclasses import dataclass, field
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    ClassVar,
+    Collection,
+    Mapping,
+    Optional,
+    Union,
+)
+
+from archytas.chat_history import ChatHistory, SerdeSchema
+
+if TYPE_CHECKING:
+    from archytas.models.base import BaseArchytasModel
+
+__all__ = [
+    "BEAKER_CHAT_HISTORY_SCHEMA",
+    "CELL_LINKS_SCHEMA",
+    "CellRef",
+    "ToolCallLink",
+    "HumanCellLink",
+    "AICellLink",
+    "ToolCellLink",
+    "CellLink",
+    "BeakerChatHistoryDoc",
+]
+
+
+# Envelope schema for the Beaker chat-history document. Versioned independently
+# of the Archytas ``CHAT_HISTORY_SCHEMA`` it wraps.
+BEAKER_CHAT_HISTORY_SCHEMA = SerdeSchema(name="beaker.ChatHistory", version=1)
+
+# Schema for the cell-link overlay. Versioned separately from the envelope so
+# the (more volatile) link shape can evolve without bumping the document schema.
+CELL_LINKS_SCHEMA = SerdeSchema(name="beaker.ChatHistoryCellLinks", version=1)
+
+# Histories whose serialized Archytas payload exceeds this many bytes are
+# gzip+base64 compressed when ``compress="auto"``.
+DEFAULT_COMPRESS_THRESHOLD = 64 * 1024
+
+# Encoding markers for the inner ``history`` payload.
+_ENCODING_JSON = "json"
+_ENCODING_GZIP_B64 = "gzip+base64"
+
+# Fields in the Archytas history payload that Beaker intentionally clears when
+# saving. Both are regenerated from the agent/context at load time, so a stored
+# snapshot would only go stale. The user preamble is deliberately NOT listed --
+# it can carry user-authored text that cannot be regenerated.
+_OMITTED_HISTORY_FIELDS = ("system_message", "system_preamble")
+
+# Sentinel so callers can omit summarizers (letting Archytas apply its own
+# defaults) while still being able to pass ``None`` to disable them explicitly.
+_UNSET: Any = object()
+
+
+def _check_schema(data: Mapping[str, Any], expected: SerdeSchema, key: str = "format") -> None:
+    """Warn (never raise) when the document's declared schema is absent or drifts.
+
+    Mirrors the lenient posture of the Archytas serde: older/newer envelopes are
+    still loaded best-effort, but the drift is surfaced for inspection.
+    """
+    raw = data.get(key)
+    if not raw:
+        warnings.warn(
+            f"Beaker chat-history document is missing a '{key}' schema marker; "
+            f"expected {expected.to_dict()}. Attempting to load anyway.",
+            stacklevel=3,
+        )
+        return
+    found = SerdeSchema.from_dict(raw)
+    if not found.is_compatible(expected):
+        warnings.warn(
+            f"Beaker chat-history document schema {found.to_dict()} is not "
+            f"compatible with expected {expected.to_dict()}. Attempting to load anyway.",
+            stacklevel=3,
+        )
+
+
+def _compress_history(payload: Mapping[str, Any]) -> str:
+    """gzip+base64 a JSON-compatible payload into an ASCII string."""
+    raw = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    return base64.b64encode(gzip.compress(raw)).decode("ascii")
+
+
+def _decompress_history(blob: str) -> dict[str, Any]:
+    """Inverse of :func:`_compress_history`."""
+    raw = gzip.decompress(base64.b64decode(blob.encode("ascii")))
+    return json.loads(raw.decode("utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# Cell-link overlay value types (tagged union keyed by message ``kind``).
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CellRef:
+    """A single notebook cell, tagged with its ``beaker_cell_type``.
+
+    ``cell_type`` is the cell's role (``code``, ``user_question``, ``response``,
+    ``error`` ...); ``cell`` is its notebook cell id.
+    """
+
+    cell: str
+    cell_type: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"type": self.cell_type, "cell": self.cell}
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "CellRef":
+        return cls(cell=data["cell"], cell_type=data["type"])
+
+
+@dataclass
+class ToolCallLink:
+    """The cell(s) produced by a single tool call.
+
+    ``cells`` holds zero-or-more :class:`CellRef`. An empty list marks a
+    cell-bearing tool call whose cell could not be matched (drift); a tool call
+    that never produces a cell is simply omitted from its message's
+    ``tool_calls`` rather than carried as an empty entry.
+    """
+
+    tool: str
+    cells: list[CellRef] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"tool": self.tool, "cells": [c.to_dict() for c in self.cells]}
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "ToolCallLink":
+        return cls(
+            tool=data["tool"],
+            cells=[CellRef.from_dict(c) for c in data.get("cells") or []],
+        )
+
+
+@dataclass
+class HumanCellLink:
+    """Link for a ``HumanMessage`` (the loop-initiating query) -> one query cell.
+
+    ``cell`` is ``None`` when no query cell could be matched (drift).
+    """
+
+    kind: ClassVar[str] = "human"
+    cell: Optional[str] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"kind": self.kind, "cell": self.cell}
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "HumanCellLink":
+        return cls(cell=data.get("cell"))
+
+
+@dataclass
+class AICellLink:
+    """Link for an ``AIMessage`` -> an optional thought cell plus per-tool-call cells.
+
+    ``thought_cell`` is ``None`` for the terminal AIMessage (``final_answer`` /
+    ``fail_task`` thoughts are not rendered) or when a thought cell could not be
+    matched. ``tool_calls`` is keyed by ``tool_call_id``.
+    """
+
+    kind: ClassVar[str] = "ai"
+    thought_cell: Optional[str] = None
+    tool_calls: dict[str, ToolCallLink] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "thought_cell": self.thought_cell,
+            "tool_calls": {
+                tool_call_id: link.to_dict()
+                for tool_call_id, link in self.tool_calls.items()
+            },
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "AICellLink":
+        return cls(
+            thought_cell=data.get("thought_cell"),
+            tool_calls={
+                tool_call_id: ToolCallLink.from_dict(link)
+                for tool_call_id, link in (data.get("tool_calls") or {}).items()
+            },
+        )
+
+
+@dataclass
+class ToolCellLink:
+    """Link for a ``ToolMessage`` (one tool result) -> zero-or-more cells.
+
+    Carries ``tool_call_id``/``tool`` so a tool result resolves to its cell(s)
+    directly, without having to walk back to the calling AIMessage.
+    """
+
+    kind: ClassVar[str] = "tool"
+    tool_call_id: str = ""
+    tool: str = ""
+    cells: list[CellRef] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "tool_call_id": self.tool_call_id,
+            "tool": self.tool,
+            "cells": [c.to_dict() for c in self.cells],
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "ToolCellLink":
+        return cls(
+            tool_call_id=data.get("tool_call_id", ""),
+            tool=data.get("tool", ""),
+            cells=[CellRef.from_dict(c) for c in data.get("cells") or []],
+        )
+
+
+CellLink = Union[HumanCellLink, AICellLink, ToolCellLink]
+
+_CELL_LINK_TYPES: dict[str, type] = {
+    HumanCellLink.kind: HumanCellLink,
+    AICellLink.kind: AICellLink,
+    ToolCellLink.kind: ToolCellLink,
+}
+
+
+def _cell_link_from_dict(data: Mapping[str, Any]) -> CellLink:
+    """Dispatch a serialized cell link to its concrete type by ``kind``."""
+    kind = data.get("kind")
+    link_cls = _CELL_LINK_TYPES.get(kind)
+    if link_cls is None:
+        raise ValueError(f"Unknown cell-link kind: {kind!r}")
+    return link_cls.from_dict(data)
+
+
+def _link_cell_ids(link: CellLink) -> list[str]:
+    """All notebook cell ids referenced by a single link (order-preserving)."""
+    if isinstance(link, HumanCellLink):
+        return [link.cell] if link.cell else []
+    if isinstance(link, AICellLink):
+        ids: list[str] = []
+        if link.thought_cell:
+            ids.append(link.thought_cell)
+        for tool_call in link.tool_calls.values():
+            ids.extend(ref.cell for ref in tool_call.cells)
+        return ids
+    if isinstance(link, ToolCellLink):
+        return [ref.cell for ref in link.cells]
+    return []
+
+
+@dataclass
+class BeakerChatHistoryDoc:
+    """A versioned, round-trippable Beaker envelope around an Archytas ChatHistory.
+
+    Attributes:
+        history: The wrapped Archytas chat history.
+        cell_links: Advisory mapping of chat-history record ``uuid`` ->
+            :class:`CellLink`. Optional and lossy by design (see module
+            docstring).
+        metadata: Beaker-specific, non-reconstructive metadata (e.g. context
+            slug). Free-form and round-tripped verbatim.
+    """
+
+    history: ChatHistory
+    cell_links: dict[str, CellLink] = field(default_factory=dict)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_history(
+        cls,
+        history: ChatHistory,
+        cell_links: Optional[Mapping[str, CellLink]] = None,
+        metadata: Optional[Mapping[str, Any]] = None,
+    ) -> "BeakerChatHistoryDoc":
+        """Build a document from a live history plus an optional cell-link overlay."""
+        return cls(
+            history=history,
+            cell_links=dict(cell_links or {}),
+            metadata=dict(metadata or {}),
+        )
+
+    # -- cell-link helpers ---------------------------------------------------
+
+    def link_for(self, record_uuid: str) -> Optional[CellLink]:
+        """Return the :class:`CellLink` for ``record_uuid``, or ``None``."""
+        return self.cell_links.get(record_uuid)
+
+    def referenced_cell_ids(self) -> set[str]:
+        """All notebook cell ids referenced anywhere in the overlay."""
+        ids: set[str] = set()
+        for link in self.cell_links.values():
+            ids.update(_link_cell_ids(link))
+        return ids
+
+    def prune_cell_links(self, valid_cell_ids: Collection[str]) -> list[str]:
+        """Drop references to cells no longer present in the notebook.
+
+        Removes any :class:`CellRef` (and nulls any scalar ``cell`` /
+        ``thought_cell``) whose target is not in ``valid_cell_ids``, leaving the
+        record entries in place so a now-empty link still documents the drift.
+        Returns the removed cell ids (with multiplicity). The history itself is
+        unaffected.
+        """
+        valid = set(valid_cell_ids)
+        dropped: list[str] = []
+
+        def _filter(cells: list[CellRef]) -> list[CellRef]:
+            kept: list[CellRef] = []
+            for ref in cells:
+                if ref.cell in valid:
+                    kept.append(ref)
+                else:
+                    dropped.append(ref.cell)
+            return kept
+
+        for link in self.cell_links.values():
+            if isinstance(link, HumanCellLink):
+                if link.cell is not None and link.cell not in valid:
+                    dropped.append(link.cell)
+                    link.cell = None
+            elif isinstance(link, AICellLink):
+                if link.thought_cell is not None and link.thought_cell not in valid:
+                    dropped.append(link.thought_cell)
+                    link.thought_cell = None
+                for tool_call in link.tool_calls.values():
+                    tool_call.cells = _filter(tool_call.cells)
+            elif isinstance(link, ToolCellLink):
+                link.cells = _filter(link.cells)
+
+        return dropped
+
+    # -- serde ---------------------------------------------------------------
+
+    def to_dict(
+        self,
+        compress: bool | str = "auto",
+        compress_threshold: int = DEFAULT_COMPRESS_THRESHOLD,
+    ) -> dict[str, Any]:
+        """Serialize to a JSON-compatible envelope document.
+
+        Args:
+            compress: ``True``/``False`` to force or forbid gzip+base64 of the
+                inner Archytas history payload, or ``"auto"`` (default) to
+                compress only when the serialized payload exceeds
+                ``compress_threshold`` bytes.
+            compress_threshold: Byte threshold for ``compress="auto"``.
+        """
+        history_payload = self.history.to_dict()
+        # Drop the regenerable framing fields before measuring/compressing so the
+        # stored payload reflects what is actually persisted.
+        for omitted in _OMITTED_HISTORY_FIELDS:
+            if omitted in history_payload:
+                history_payload[omitted] = None
+
+        if isinstance(compress, str):
+            if compress != "auto":
+                raise ValueError(f"Unknown compress mode: {compress!r}")
+            measured = len(
+                json.dumps(history_payload, separators=(",", ":")).encode("utf-8")
+            )
+            do_compress = measured > compress_threshold
+        else:
+            do_compress = bool(compress)
+
+        if do_compress:
+            history_field: Any = _compress_history(history_payload)
+            encoding = _ENCODING_GZIP_B64
+        else:
+            history_field = history_payload
+            encoding = _ENCODING_JSON
+
+        return {
+            "format": BEAKER_CHAT_HISTORY_SCHEMA.to_dict(),
+            "cell_links_format": CELL_LINKS_SCHEMA.to_dict(),
+            "metadata": copy.deepcopy(self.metadata),
+            "cell_links": {
+                record_uuid: link.to_dict()
+                for record_uuid, link in self.cell_links.items()
+            },
+            "history_encoding": encoding,
+            "history": history_field,
+        }
+
+    @classmethod
+    def from_dict(
+        cls,
+        data: Mapping[str, Any],
+        model: Optional["BaseArchytasModel"] = None,
+        loop_summarizer: Optional[Callable] = _UNSET,
+        history_summarizer: Optional[Callable] = _UNSET,
+    ) -> "BeakerChatHistoryDoc":
+        """Reconstruct from :meth:`to_dict` output.
+
+        ``model`` and the summarizers are not part of the serialized document;
+        supply live ones to attach to the reconstructed :class:`ChatHistory`.
+        Omit the summarizers to let Archytas apply its own defaults, or pass
+        ``None`` to disable them explicitly. Individual cell links that cannot
+        be parsed are skipped with a warning rather than failing the load --
+        the overlay is advisory.
+        """
+        _check_schema(data, expected=BEAKER_CHAT_HISTORY_SCHEMA)
+
+        encoding = data.get("history_encoding", _ENCODING_JSON)
+        history_field = data.get("history")
+        if encoding == _ENCODING_GZIP_B64:
+            if not isinstance(history_field, str):
+                raise ValueError(
+                    "history_encoding is 'gzip+base64' but 'history' is not a string."
+                )
+            history_payload = _decompress_history(history_field)
+        elif encoding == _ENCODING_JSON:
+            history_payload = dict(history_field or {})
+        else:
+            raise ValueError(f"Unknown history_encoding: {encoding!r}")
+
+        history_kwargs: dict[str, Any] = {"model": model}
+        if loop_summarizer is not _UNSET:
+            history_kwargs["loop_summarizer"] = loop_summarizer
+        if history_summarizer is not _UNSET:
+            history_kwargs["history_summarizer"] = history_summarizer
+        history = ChatHistory.from_dict(history_payload, **history_kwargs)
+
+        raw_links = data.get("cell_links") or {}
+        if raw_links:
+            _check_schema(data, expected=CELL_LINKS_SCHEMA, key="cell_links_format")
+        cell_links: dict[str, CellLink] = {}
+        for record_uuid, raw in raw_links.items():
+            try:
+                cell_links[record_uuid] = _cell_link_from_dict(raw)
+            except (KeyError, ValueError, TypeError) as exc:
+                warnings.warn(
+                    f"Skipping unparseable cell link for record {record_uuid!r}: {exc}",
+                    stacklevel=2,
+                )
+
+        return cls(
+            history=history,
+            cell_links=cell_links,
+            metadata=dict(data.get("metadata") or {}),
+        )

--- a/tests/test_chat_history_serde.py
+++ b/tests/test_chat_history_serde.py
@@ -1,0 +1,409 @@
+"""
+Tests for beaker_notebook.lib.chat_history (BeakerChatHistoryDoc serde).
+
+Covers:
+- envelope schema marker + JSON-serializability
+- round-trip preservation of records, uuids, react_loop_id, summaries
+- structured cell-link overlay (human / ai / tool kinds, cells lists)
+- cell-link round-trip, drift handling (prune / empty cells), lenient skip
+- beaker metadata round-trip
+- compression: forced on/off, "auto" thresholding, cleartext envelope
+- lenient schema checking (warns, never raises) on missing/incompatible markers
+- from_dict summarizer passthrough vs. default
+"""
+
+import json
+import warnings
+
+import pytest
+
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
+
+from archytas.chat_history import ChatHistory, MessageRecord, SummaryRecord
+
+from beaker_notebook.lib.chat_history import (
+    BEAKER_CHAT_HISTORY_SCHEMA,
+    CELL_LINKS_SCHEMA,
+    AICellLink,
+    BeakerChatHistoryDoc,
+    CellRef,
+    HumanCellLink,
+    ToolCallLink,
+    ToolCellLink,
+)
+
+
+# -- fixtures / helpers --
+
+
+def _make_history() -> ChatHistory:
+    """A history with a system message, three raw records, and one summary.
+
+    Records model one ReAct step: a query (Human), a thought + run_code call
+    (AI), and the run_code result (Tool).
+    """
+    history = ChatHistory(
+        messages=[
+            HumanMessage(content="what is 2 + 2?"),
+            AIMessage(content="computing the sum"),
+        ]
+    )
+    history.add_message(ToolMessage(content="4", tool_call_id="tc1"))
+    history.set_system_message("you are a test agent")
+    for record in history.raw_records:
+        record.react_loop_id = 7
+    history.summaries.append(
+        SummaryRecord(
+            message=SystemMessage(content="summary of earlier turns"),
+            summarized_messages={"alpha", "beta"},
+        )
+    )
+    return history
+
+
+def _make_links(history: ChatHistory) -> dict:
+    """A representative overlay: human query, ai thought + tool call, tool result."""
+    human_uuid, ai_uuid, tool_uuid = (r.uuid for r in history.raw_records)
+    code_ref = CellRef(cell="code-cell", cell_type="code")
+    return {
+        human_uuid: HumanCellLink(cell="query-cell"),
+        ai_uuid: AICellLink(
+            thought_cell="thought-cell",
+            tool_calls={"tc1": ToolCallLink(tool="run_code", cells=[code_ref])},
+        ),
+        tool_uuid: ToolCellLink(
+            tool_call_id="tc1", tool="run_code", cells=[CellRef(cell="code-cell", cell_type="code")]
+        ),
+    }
+
+
+@pytest.fixture
+def history() -> ChatHistory:
+    return _make_history()
+
+
+@pytest.fixture
+def doc(history: ChatHistory) -> BeakerChatHistoryDoc:
+    return BeakerChatHistoryDoc.from_history(
+        history,
+        cell_links=_make_links(history),
+        metadata={"context": "test"},
+    )
+
+
+# -- envelope / schema --
+
+
+def test_to_dict_carries_schema_markers(doc):
+    data = doc.to_dict()
+    assert data["format"] == BEAKER_CHAT_HISTORY_SCHEMA.to_dict()
+    assert data["format"] == {"schema": "beaker.ChatHistory", "version": 1}
+    assert data["cell_links_format"] == CELL_LINKS_SCHEMA.to_dict()
+    assert data["cell_links_format"] == {"schema": "beaker.ChatHistoryCellLinks", "version": 1}
+
+
+def test_to_dict_is_json_serializable(doc):
+    # Must survive a real JSON encode/decode (notebook metadata is JSON).
+    encoded = json.dumps(doc.to_dict())
+    assert isinstance(encoded, str)
+    json.loads(encoded)
+
+
+# -- round-trip preservation (history) --
+
+
+def test_round_trip_preserves_records_and_uuids(doc, history):
+    orig_uuids = [r.uuid for r in history.raw_records]
+    restored = BeakerChatHistoryDoc.from_dict(doc.to_dict(compress=False))
+
+    assert [r.uuid for r in restored.history.raw_records] == orig_uuids
+    assert restored.history.raw_records[0].message.text == "what is 2 + 2?"
+    assert restored.history.raw_records[2].message.text == "4"
+
+
+def test_round_trip_preserves_react_loop_id(doc):
+    restored = BeakerChatHistoryDoc.from_dict(doc.to_dict(compress=False))
+    assert [r.react_loop_id for r in restored.history.raw_records] == [7, 7, 7]
+
+
+def test_round_trip_preserves_summaries(doc, history):
+    sum_uuid = history.summaries[0].uuid
+    restored = BeakerChatHistoryDoc.from_dict(doc.to_dict(compress=False))
+
+    assert len(restored.history.summaries) == 1
+    summary = restored.history.summaries[0]
+    assert isinstance(summary, SummaryRecord)
+    assert summary.uuid == sum_uuid
+    assert summary.summarized_messages == {"alpha", "beta"}
+
+
+def test_round_trip_preserves_metadata(doc):
+    restored = BeakerChatHistoryDoc.from_dict(doc.to_dict(compress=False))
+    assert restored.metadata == {"context": "test"}
+
+
+# -- structured cell links --
+
+
+def test_round_trip_preserves_structured_cell_links(doc, history):
+    expected = _make_links(history)
+    restored = BeakerChatHistoryDoc.from_dict(doc.to_dict(compress=False))
+    assert restored.cell_links == expected
+
+
+def test_cell_link_value_shapes_in_serialized_form(doc, history):
+    human_uuid, ai_uuid, tool_uuid = (r.uuid for r in history.raw_records)
+    data = doc.to_dict(compress=False)["cell_links"]
+
+    assert data[human_uuid] == {"kind": "human", "cell": "query-cell"}
+    assert data[ai_uuid] == {
+        "kind": "ai",
+        "thought_cell": "thought-cell",
+        "tool_calls": {
+            "tc1": {"tool": "run_code", "cells": [{"type": "code", "cell": "code-cell"}]}
+        },
+    }
+    assert data[tool_uuid] == {
+        "kind": "tool",
+        "tool_call_id": "tc1",
+        "tool": "run_code",
+        "cells": [{"type": "code", "cell": "code-cell"}],
+    }
+
+
+def test_tool_call_supports_multiple_and_zero_cells(history):
+    ai_uuid = history.raw_records[1].uuid
+    links = {
+        ai_uuid: AICellLink(
+            tool_calls={
+                "many": ToolCallLink(
+                    tool="hypothetical",
+                    cells=[
+                        CellRef(cell="c1", cell_type="code"),
+                        CellRef(cell="c2", cell_type="code"),
+                    ],
+                ),
+                "drifted": ToolCallLink(tool="run_code", cells=[]),  # expected-but-unmatched
+            }
+        )
+    }
+    doc = BeakerChatHistoryDoc.from_history(history, cell_links=links)
+    restored = BeakerChatHistoryDoc.from_dict(doc.to_dict(compress=False))
+
+    tool_calls = restored.cell_links[ai_uuid].tool_calls
+    assert [r.cell for r in tool_calls["many"].cells] == ["c1", "c2"]
+    assert tool_calls["drifted"].cells == []
+
+
+def test_link_for_and_referenced_cell_ids(doc, history):
+    human_uuid = history.raw_records[0].uuid
+    assert doc.link_for(human_uuid) == HumanCellLink(cell="query-cell")
+    assert doc.link_for("does-not-exist") is None
+    assert doc.referenced_cell_ids() == {"query-cell", "thought-cell", "code-cell"}
+
+
+def test_prune_cell_links_drops_stale_refs(doc, history):
+    human_uuid, ai_uuid, tool_uuid = (r.uuid for r in history.raw_records)
+    # Keep the query + thought cells; drop the code cell (referenced twice).
+    dropped = doc.prune_cell_links(valid_cell_ids={"query-cell", "thought-cell"})
+
+    assert dropped.count("code-cell") == 2
+    # Entries remain; the now-empty cells document the drift.
+    assert doc.cell_links[ai_uuid].tool_calls["tc1"].cells == []
+    assert doc.cell_links[tool_uuid].cells == []
+    # Surviving links untouched.
+    assert doc.cell_links[human_uuid].cell == "query-cell"
+    assert doc.cell_links[ai_uuid].thought_cell == "thought-cell"
+
+
+def test_prune_nulls_scalar_cells(history):
+    human_uuid, ai_uuid = history.raw_records[0].uuid, history.raw_records[1].uuid
+    links = {
+        human_uuid: HumanCellLink(cell="gone"),
+        ai_uuid: AICellLink(thought_cell="also-gone"),
+    }
+    doc = BeakerChatHistoryDoc.from_history(history, cell_links=links)
+    dropped = doc.prune_cell_links(valid_cell_ids=set())
+
+    assert sorted(dropped) == ["also-gone", "gone"]
+    assert doc.cell_links[human_uuid].cell is None
+    assert doc.cell_links[ai_uuid].thought_cell is None
+
+
+def test_history_functional_without_cell_links(history):
+    doc = BeakerChatHistoryDoc.from_history(history)
+    restored = BeakerChatHistoryDoc.from_dict(doc.to_dict(compress=False))
+
+    assert restored.cell_links == {}
+    assert [r.uuid for r in restored.history.raw_records] == [
+        r.uuid for r in history.raw_records
+    ]
+
+
+def test_unparseable_cell_link_is_skipped_with_warning(doc, history):
+    data = doc.to_dict(compress=False)
+    data["cell_links"]["bogus-uuid"] = {"kind": "nonsense"}
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        restored = BeakerChatHistoryDoc.from_dict(data)
+    assert any("Skipping unparseable cell link" in str(w.message) for w in caught)
+    assert "bogus-uuid" not in restored.cell_links
+    # Valid links still loaded.
+    assert len(restored.cell_links) == len(history.raw_records)
+
+
+# -- framing-field omission policy --
+
+
+def _history_with_preambles() -> ChatHistory:
+    history = ChatHistory(messages=[HumanMessage(content="hi")])
+    history.set_system_message("you are a test agent")
+    history.system_preamble = MessageRecord(message=SystemMessage(content="system preamble"))
+    history.user_preamble = MessageRecord(message=HumanMessage(content="user preamble"))
+    return history
+
+
+def test_save_clears_system_message_and_system_preamble():
+    doc = BeakerChatHistoryDoc.from_history(_history_with_preambles())
+    payload = doc.to_dict(compress=False)["history"]
+
+    assert payload["system_message"] is None
+    assert payload["system_preamble"] is None
+    # user_preamble is retained (user-authored, not regenerable).
+    assert payload["user_preamble"] is not None
+
+
+def test_round_trip_keeps_user_preamble_drops_regenerable_framing():
+    doc = BeakerChatHistoryDoc.from_history(_history_with_preambles())
+    restored = BeakerChatHistoryDoc.from_dict(doc.to_dict(compress=False))
+
+    assert restored.history.system_message is None
+    assert restored.history.system_preamble is None
+    assert restored.history.user_preamble is not None
+    assert restored.history.user_preamble.message.text == "user preamble"
+
+
+def test_omission_holds_under_compression():
+    doc = BeakerChatHistoryDoc.from_history(_history_with_preambles())
+    restored = BeakerChatHistoryDoc.from_dict(doc.to_dict(compress=True))
+
+    assert restored.history.system_message is None
+    assert restored.history.system_preamble is None
+    assert restored.history.user_preamble.message.text == "user preamble"
+
+
+# -- compression --
+
+
+def test_compress_false_keeps_history_inline(doc):
+    data = doc.to_dict(compress=False)
+    assert data["history_encoding"] == "json"
+    assert isinstance(data["history"], dict)
+
+
+def test_compress_true_encodes_history_as_string(doc):
+    data = doc.to_dict(compress=True)
+    assert data["history_encoding"] == "gzip+base64"
+    assert isinstance(data["history"], str)
+
+
+def test_compressed_envelope_stays_cleartext(doc, history):
+    # Schema, metadata, and cell links must remain inspectable without
+    # decompressing the inner payload.
+    data = doc.to_dict(compress=True)
+    assert data["format"] == BEAKER_CHAT_HISTORY_SCHEMA.to_dict()
+    assert data["cell_links_format"] == CELL_LINKS_SCHEMA.to_dict()
+    assert data["metadata"] == {"context": "test"}
+    human_uuid = history.raw_records[0].uuid
+    assert data["cell_links"][human_uuid] == {"kind": "human", "cell": "query-cell"}
+
+
+def test_compressed_round_trip(doc, history):
+    restored = BeakerChatHistoryDoc.from_dict(doc.to_dict(compress=True))
+    assert [r.uuid for r in restored.history.raw_records] == [
+        r.uuid for r in history.raw_records
+    ]
+    assert restored.history.summaries[0].summarized_messages == {"alpha", "beta"}
+    assert restored.cell_links == _make_links(history)
+
+
+def test_auto_compression_below_threshold_stays_inline(doc):
+    data = doc.to_dict(compress="auto", compress_threshold=10**9)
+    assert data["history_encoding"] == "json"
+
+
+def test_auto_compression_above_threshold_compresses(doc):
+    data = doc.to_dict(compress="auto", compress_threshold=0)
+    assert data["history_encoding"] == "gzip+base64"
+
+
+def test_invalid_compress_mode_raises(doc):
+    with pytest.raises(ValueError):
+        doc.to_dict(compress="sometimes")
+
+
+def test_from_dict_rejects_bad_encoding(doc):
+    data = doc.to_dict(compress=False)
+    data["history_encoding"] = "rot13"
+    with pytest.raises(ValueError):
+        BeakerChatHistoryDoc.from_dict(data)
+
+
+def test_from_dict_rejects_compressed_marker_with_non_string_body(doc):
+    data = doc.to_dict(compress=False)
+    data["history_encoding"] = "gzip+base64"  # but history is still a dict
+    with pytest.raises(ValueError):
+        BeakerChatHistoryDoc.from_dict(data)
+
+
+# -- lenient schema checking --
+
+
+def test_incompatible_schema_warns_but_loads(doc):
+    data = doc.to_dict(compress=False)
+    data["format"] = {"schema": "beaker.ChatHistory", "version": 999}
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        restored = BeakerChatHistoryDoc.from_dict(data)
+    assert any("not compatible" in str(w.message) for w in caught)
+    assert len(restored.history.raw_records) == 3
+
+
+def test_missing_schema_marker_warns_but_loads(doc):
+    data = doc.to_dict(compress=False)
+    del data["format"]
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        restored = BeakerChatHistoryDoc.from_dict(data)
+    assert any("missing a 'format'" in str(w.message) for w in caught)
+    assert len(restored.history.raw_records) == 3
+
+
+def test_incompatible_cell_links_schema_warns_but_loads(doc, history):
+    data = doc.to_dict(compress=False)
+    data["cell_links_format"] = {"schema": "beaker.ChatHistoryCellLinks", "version": 999}
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        restored = BeakerChatHistoryDoc.from_dict(data)
+    assert any("not compatible" in str(w.message) for w in caught)
+    assert restored.cell_links == _make_links(history)
+
+
+# -- summarizer passthrough --
+
+
+def test_from_dict_uses_archytas_default_summarizers_when_omitted(doc):
+    restored = BeakerChatHistoryDoc.from_dict(doc.to_dict(compress=False))
+    # Default omission -> Archytas attaches its own defaults (non-None).
+    assert restored.history.loop_summarizer is not None
+    assert restored.history.history_summarizer is not None
+
+
+def test_from_dict_can_disable_summarizers_explicitly(doc):
+    restored = BeakerChatHistoryDoc.from_dict(
+        doc.to_dict(compress=False),
+        loop_summarizer=None,
+        history_summarizer=None,
+    )
+    assert restored.history.loop_summarizer is None
+    assert restored.history.history_summarizer is None


### PR DESCRIPTION
## Summary

Adds `BeakerChatHistoryDoc`, a versioned, round-trippable envelope that wraps an Archytas `ChatHistory` for inclusion in a saved notebook. This is the **format layer** for conversation persistence — it defines how a Beaker agent's chat history converts to/from a JSON-compatible dict, including an optional overlay linking history records to notebook cells. Actually computing those links from a live notebook, and the save/load/rehydrate wiring, will be worked via issue #225.

## What's included

  - `src/beaker_notebook/lib/chat_history.py` — `BeakerChatHistoryDoc` + serde.
  - `tests/test_chat_history_serde.py` — unit coverage (round-trip, cell links, compression, omission policy, lenient loading).
  - `pyproject.toml` — bump the `archytas` floor to the release carrying the serde + faithful preamble round-trip.

## Features
- **Delegates message serde to Archytas.**
- **Reified, independently-versioned schemas.**
- **Optional compression.**
- **Lenient loading.**