### PR TITLE
Fix/provider onboarding flow

### DIFF
--- a/beaker-vue/src/components/cell/BaseQueryCell.ts
+++ b/beaker-vue/src/components/cell/BaseQueryCell.ts
@@ -39,6 +39,13 @@ export const useBaseQueryCell = (props) => {
             });
             msg.cell = cell.value;
           }
+          // Tag auth-failure messages with the originating cell so the model
+          // configuration dialog can re-run this query once credentials are
+          // provided (otherwise the user's prompt is silently dropped).
+          else if (msg.header?.msg_type === 'llm_auth_failure') {
+            msg.cell = cell.value;
+          }
+          return true;
         }
       )
     });

--- a/beaker-vue/src/components/misc/ProviderSelector.vue
+++ b/beaker-vue/src/components/misc/ProviderSelector.vue
@@ -258,9 +258,14 @@ onBeforeMount(() => {
     }
 }
 
-#config-panel-provider {
+#provider-select-providers {
     grid-area: provider;
-    background-color: blue;
+    // Allow the form to scroll within its grid cell instead of overflowing
+    // down onto the dialog buttons row. `min-height: 0` is required for a
+    // grid item to shrink below its content size and enable scrolling.
+    min-height: 0;
+    overflow-y: auto;
+    padding: 0 0.5rem 0.5rem 1rem;
 }
 
 .p-listbox-item {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "archytas>=2.0.3",
+  "archytas>=2.0.4",
   "jupyterlab~=4.0",
   "jupyterlab-server>=2.22.1,<3",
   "requests>=2.24,<3",

--- a/src/beaker_notebook/app/handlers.py
+++ b/src/beaker_notebook/app/handlers.py
@@ -157,12 +157,16 @@ class ConfigController(JupyterHandler):
             if type_args:
                 if isinstance(type_obj, UnionType):
                     type_def["type_str"] = repr(type_obj)
-                elif issubclass(type_origin, Choice):
+                elif isinstance(type_origin, type) and issubclass(type_origin, Choice):
                     source = get_args(type_args[0])[0]
                     type_def["type_str"] = f"{type_origin.__name__}['{source}']"
                     type_def["choice_source"] = source
+                elif isinstance(type_origin, type):
+                    type_def["type_str"] = f"{type_origin.__name__}[{', '.join(getattr(arg, '__name__', repr(arg)) for arg in type_args)}]"
                 else:
-                    type_def["type_str"] = f"{type_origin.__name__}[{', '.join(arg.__name__ for arg in type_args)}]"
+                    # Non-class origins (e.g. typing.Literal[...]) have no __name__
+                    # and aren't valid issubclass() args; represent them directly.
+                    type_def["type_str"] = repr(type_obj)
                 if type_origin:
                     type_def["type_origin"] = ConfigController.map_type(type_origin)
                 if type_args:
@@ -185,7 +189,8 @@ class ConfigController(JupyterHandler):
                     type_def["default_value"] = default_value
                 except TypeError:
                     pass
-        except:
+        except Exception:
+            logger.exception("Failed to build config schema for type %r; falling back to repr", type_obj)
             type_def["type_str"] = repr(type_obj)
         return type_def
 
@@ -202,7 +207,13 @@ class ConfigController(JupyterHandler):
             description = metadata.pop("description", None)
             option_func = metadata.pop("options", None)
             if option_func and callable(option_func):
-                metadata["options"] = option_func()
+                try:
+                    metadata["options"] = option_func()
+                except Exception:
+                    # A failing options provider must not blank out the field (and,
+                    # for nested schemas, the entire config form). Degrade gracefully.
+                    logger.exception("Failed to resolve options for config field %r", field_name)
+                    metadata["options"] = None
             field_result = {
                 "name": field.name,
                 "description": description,

--- a/src/beaker_notebook/kernel.py
+++ b/src/beaker_notebook/kernel.py
@@ -797,7 +797,9 @@ class BeakerKernel(KernelProxyManager):
             reset_config()
             model = config.get_model()
         if model:
-            self.context.agent.model = model
+            # set_model updates both the agent's model and the chat history's
+            # (the UI reads model metadata + token budgets from the latter).
+            self.context.agent.set_model(model)
         await self.send_set_chat_history(message.header)
 
     @message_handler

--- a/src/beaker_notebook/lib/config.py
+++ b/src/beaker_notebook/lib/config.py
@@ -1,4 +1,5 @@
 import binascii
+import functools
 import importlib.resources
 import dotenv
 import importlib
@@ -18,16 +19,31 @@ from beaker_notebook.lib.utils import DefaultModel
 logger = logging.getLogger(__name__)
 
 
-def get_providers() -> dict[str, str]:
+@functools.lru_cache(maxsize=1)
+def _discover_provider_import_paths() -> tuple[tuple[str, str], ...]:
+    """Discover available archytas model provider classes as (name, import_path).
+
+    Cached because the set of model modules is fixed for the life of a process,
+    and a failed import is *not* memoized by ``importlib`` -- so without caching
+    every call re-attempts (and re-logs) any broken module. Returns an immutable
+    tuple so the cache can't be mutated by callers.
+    """
     import archytas.models
     from archytas.models.base import BaseArchytasModel
     base_class = BaseArchytasModel
-    result = {}
+    result: dict[str, str] = {}
     for resource in importlib.resources.files(archytas.models).iterdir():
         if resource.is_file() and resource.name.endswith('.py'):
             name = resource.name.split('.', 1)[0]
             mod_name = f'archytas.models.{name}'
-            mod = importlib.import_module(mod_name, 'archytas.models')
+            try:
+                mod = importlib.import_module(mod_name, 'archytas.models')
+            except Exception as err:
+                # A single model module that fails to import (e.g. an upstream
+                # dependency mismatch) must not take down provider discovery and,
+                # with it, the entire config/provider-selection UI. Skip it.
+                logger.warning("Skipping archytas model module %r: failed to import (%s)", mod_name, err)
+                continue
             items = inspect.getmembers(
                 mod,
                 lambda item:
@@ -36,7 +52,11 @@ def get_providers() -> dict[str, str]:
                     item is not base_class
             )
             result.update({item[0]: f"{item[1].__module__}.{item[1].__name__}" for item in items})
-    return result
+    return tuple(result.items())
+
+
+def get_providers() -> dict[str, str]:
+    return dict(_discover_provider_import_paths())
 
 
 CONFIG_FILE_SEARCH_LOCATIONS = [  # (path, filename, check_parent_paths, default)

--- a/tests/test_get_providers_resilience.py
+++ b/tests/test_get_providers_resilience.py
@@ -1,0 +1,39 @@
+"""Regression test for provider discovery tolerating broken model modules.
+
+A single archytas model module that fails to import (e.g. an upstream
+dependency mismatch) must not take down provider discovery and, with it, the
+entire config/provider-selection UI.
+"""
+import importlib
+
+import beaker_notebook.lib.config as config_mod
+
+
+def test_get_providers_tolerates_failing_imports(monkeypatch):
+    # Force every per-module import to fail; discovery must degrade to an empty
+    # mapping rather than raising.
+    config_mod._discover_provider_import_paths.cache_clear()
+
+    def always_fail(name, package=None):
+        raise ImportError(f"simulated failure importing {name}")
+
+    monkeypatch.setattr(importlib, "import_module", always_fail)
+    try:
+        providers = config_mod.get_providers()
+    finally:
+        config_mod._discover_provider_import_paths.cache_clear()
+
+    assert providers == {}
+
+
+def test_get_providers_returns_fresh_mapping():
+    # The cached discovery is immutable; callers get a fresh dict each call so
+    # mutating the result can't corrupt the cache.
+    config_mod._discover_provider_import_paths.cache_clear()
+    try:
+        first = config_mod.get_providers()
+        first["__sentinel__"] = "x"
+        second = config_mod.get_providers()
+        assert "__sentinel__" not in second
+    finally:
+        config_mod._discover_provider_import_paths.cache_clear()


### PR DESCRIPTION
## Summary

Fixes the brand-new-user onboarding flow: configure a provider → enter an API key → use the agent. Four independent commits, each one fix:

1. **config: don't let one broken model module break the provider config UI.** `get_providers()` imported every archytas model module; a single failing import (e.g. an upstream dependency mismatch) bubbled up through the config-schema builder and blanked the entire provider-configuration dialog (no API-key field at all). Failing modules are now skipped with a warning, discovery is cached so broken imports aren't re-attempted/re-logged each call, and `ConfigController.map_type` no longer crashes on non-class type origins (e.g. `typing.Literal[...]`) or swallows errors silently.

2. **ui: provider-config form no longer overlaps the dialog buttons.** The form was styled via a dead id (`#config-panel-provider`, left with a debug `background-color: blue`), so it was never placed in its grid cell and its fields overflowed onto the Reset/Cancel/Save row. Pointed the rule at the real element and let it scroll within the cell.

3. **ui: re-run the originating query after configuring credentials.** The query cell only tagged `msg.cell` for the "Request interrupted" case, so on an`llm_auth_failure` the model-config dialog had no cell to re-run — the user's prompt was silently dropped and had to be re-typed. Now the originating cell is tagged and re-runs once a provider is configured.

4. **kernel: sync chat-history model on live model change.** `set_agent_model` swapped the agent's model but not the chat history's, leaving the chat-history panel (which reads model metadata and token budgets from the chat history) stuck on the keyless default. Routes the change through `agent.set_model()`.

## Dependency

We call `Agent.set_model()`, and the "key takes effect immediately" behavior relies on the env-precedence fix — both from https://github.com/jataware/archytas/pull/83. Merge + release that first, then bump the `archytas>=` pin in this repo to that release.

## Tests

- `tests/test_get_providers_resilience.py` — provider discovery tolerates failing imports and returns a fresh (non-shared) mapping.

## Manual verification

Full blank-slate run (no config file): first message → provider-config modal (no overflow) → select provider, paste key → Save → key takes immediately → original prompt auto-runs → chat-history panel populates. Verified end-to-end for openai; non-openai providers were verified to bind the configured key directly.