### PR TITLE
Replace in-browser LocalStorage notebook saves with server-side .ipynb snapshots

### DIFF
--- a/beaker-vue/src/composables/index.ts
+++ b/beaker-vue/src/composables/index.ts
@@ -1,3 +1,4 @@
 export * from './useNotebookInterface';
+export * from './useNotebookSnapshot';
 export * from './useQueryCellFlattening';
 export * from './useWorkflows';

--- a/beaker-vue/src/composables/useNotebookSnapshot.ts
+++ b/beaker-vue/src/composables/useNotebookSnapshot.ts
@@ -1,0 +1,188 @@
+import { ref, nextTick, toValue, type Ref, type MaybeRefOrGetter } from 'vue';
+import { fetch } from '../util/fetch';
+import hashSum from 'hash-sum';
+import type { BeakerSessionComponentType } from '../components/session/BeakerSession.vue';
+
+export interface NotebookInfo {
+    id: string;
+    name: string;
+    created: string;
+    last_modified: string;
+    size: number;
+    session_id?: string;
+    content?: any;
+    checksum?: string;
+    metadata?: {[key: string]: any};
+}
+
+export interface UseNotebookSnapshotOptions {
+    /** Ref to the BeakerSession component instance. */
+    beakerSession: Ref<BeakerSessionComponentType | undefined>;
+    /** Default filename to associate with the notebook, if any. */
+    savefile?: MaybeRefOrGetter<string | undefined>;
+    /** Called when a loaded snapshot has content to open into the session. */
+    onOpenFile: (content: any, name: string, options: { selectedCell?: string }) => void;
+}
+
+export interface UseNotebookSnapshotReturn {
+    notebookInfo: Ref<NotebookInfo | null>;
+    saveSnapshot: () => Promise<void>;
+    loadSnapshot: () => Promise<void>;
+    startAutosave: (intervalMs?: number) => void;
+    stopAutosave: () => void;
+}
+
+/**
+ * Persists the current session's notebook to the Beaker notebook storage API
+ * (`/beaker/notebook/`) and restores it on load. Storage location and format
+ * are entirely the backend's concern; this composable only ever talks to the
+ * API endpoint.
+ */
+export function useNotebookSnapshot(options: UseNotebookSnapshotOptions): UseNotebookSnapshotReturn {
+    const { beakerSession, savefile, onOpenFile } = options;
+
+    const notebookInfo = ref<NotebookInfo | null>(null);
+    const saveInterval = ref<ReturnType<typeof setInterval> | null>(null);
+
+    const saveSnapshot = async () => {
+        const session = beakerSession.value?.session;
+        const sessionId = session?.sessionId;
+
+        const notebookData: {[key: string]: any} = {
+            ...(notebookInfo.value || {}),
+        };
+        if (notebookData.session_id && sessionId && notebookData.session_id !== sessionId) {
+            console.warn(`saveSnapshot: session id mismatch (expected ${notebookData.session_id}, got ${sessionId}); skipping save.`);
+            return;
+        }
+        notebookData.session_id = sessionId;
+
+        // Only save state if there is state to save
+        if (!session?.notebook) {
+            return;
+        }
+
+        notebookData.content = session.toIPynb();
+
+        const notebookChecksum: string = hashSum(notebookData.content);
+        const notebookComponent = beakerSession.value.notebookComponent;
+
+        if (notebookChecksum === notebookData.checksum) {
+            // No changes since last save
+            return;
+        }
+        notebookData.checksum = notebookChecksum;
+
+        if (notebookComponent) {
+            notebookData.selectedCell = notebookComponent.selectedCellId;
+        }
+
+        const savefileValue = toValue(savefile);
+        if (!notebookData.filename && typeof savefileValue === "string") {
+            notebookData.filename = savefileValue;
+        }
+
+        if (notebookData.selectedCell) {
+            // Store selected cell in notebook metadata before saving
+            notebookData.content.metadata = notebookData.content.metadata || {};
+            notebookData.content.metadata.selected_cell = notebookData.selectedCell;
+        }
+
+        const saveRequest = await fetch(`/beaker/notebook/snapshot/${sessionId}`, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify(notebookData),
+        });
+        if (saveRequest.ok) {
+            const response = await saveRequest.json();
+            notebookInfo.value = {
+                ...notebookInfo.value,
+                metadata: response,
+                checksum: notebookChecksum,
+            };
+        }
+    };
+
+    const loadSnapshot = async () => {
+        const session = beakerSession.value.session;
+        await session.sessionReady;  // Ensure content service is up
+        const sessionId = session.sessionId;
+
+        try {
+            const notebookInfoResponse = await fetch(`/beaker/notebook/snapshot/${sessionId}`);
+            if (notebookInfoResponse.ok) {
+                const response = await notebookInfoResponse.json();
+                const content = response.content;
+                const metadata = {
+                    ...response,
+                    content: undefined,
+                };
+                const checksum = hashSum(content);
+                notebookInfo.value = {
+                    ...notebookInfo.value,
+                    content,
+                    metadata,
+                    checksum,
+                };
+            }
+        }
+        catch (e) {
+            console.error(e);
+            notebookInfo.value = {
+                id: sessionId,
+                name: sessionId,
+                created: "",
+                last_modified: "",
+                size: 0,
+                session_id: sessionId,
+            };
+        }
+
+        const notebookData: {[key: string]: any} = {
+            ...(notebookInfo.value || {}),
+        };
+
+        // The selected cell is round-tripped through the notebook's metadata on save
+        // (see saveSnapshot); restore it so the previously-selected cell is reselected.
+        if (notebookData.selectedCell === undefined) {
+            notebookData.selectedCell = notebookData.content?.metadata?.selected_cell;
+        }
+
+        if (notebookData.content) {
+            onOpenFile(notebookData.content, notebookData.name, {selectedCell: notebookData.selectedCell});
+        }
+
+        if (notebookData.selectedCell !== undefined) {
+            nextTick(() => {
+                beakerSession.value.notebookComponent?.selectCell(notebookData.selectedCell);
+            });
+        }
+    };
+
+    const handleBeforeUnload = () => {
+        saveSnapshot();
+    };
+
+    const startAutosave = (intervalMs: number = 10000) => {
+        saveInterval.value = setInterval(saveSnapshot, intervalMs);
+        window.addEventListener("beforeunload", handleBeforeUnload);
+    };
+
+    const stopAutosave = () => {
+        if (saveInterval.value !== null) {
+            clearInterval(saveInterval.value);
+            saveInterval.value = null;
+        }
+        window.removeEventListener("beforeunload", handleBeforeUnload);
+    };
+
+    return {
+        notebookInfo,
+        saveSnapshot,
+        loadSnapshot,
+        startAutosave,
+        stopAutosave,
+    };
+}

--- a/beaker-vue/src/pages/BaseInterface.vue
+++ b/beaker-vue/src/pages/BaseInterface.vue
@@ -92,7 +92,7 @@
 
 <script setup lang="tsx">
 import { type ErrorObject, isErrorObject } from '../util';
-import { h, useSlots, isVNode, ref, onMounted, provide, nextTick, onUnmounted, toRaw} from 'vue';
+import { h, useSlots, isVNode, ref, onMounted, provide, onUnmounted, toRaw} from 'vue';
 import { type Component, type ComponentInstance } from 'vue';
 import Dialog from 'primevue/dialog';
 import DynamicDialog from 'primevue/dynamicdialog';
@@ -108,8 +108,7 @@ import InputText from 'primevue/inputtext';
 import InputGroup from 'primevue/inputgroup';
 import Button from 'primevue/button';
 import ProviderSelector from '../components/misc/ProviderSelector.vue';
-import { fetch } from '../util/fetch';
-import hashSum from 'hash-sum';
+import { useNotebookSnapshot } from '../composables/useNotebookSnapshot';
 
 import {default as ConfigPanel, getConfigAndSchema, dropUnchangedValues, objectifyTables, tablifyObjects, saveConfig} from '../components/panels/ConfigPanel.vue';
 import SideMenu, { type MenuPosition } from '../components/sidemenu/SideMenu.vue';
@@ -120,20 +119,7 @@ import type { DynamicDialogInstance, DynamicDialogOptions } from 'primevue/dynam
 const dialog = useDialog();
 const toast = useToast();
 
-const lastSaveChecksum = ref<string>();
 const mainRef = ref();
-const notebookInfo = ref<{
-    id: string;
-    name: string;
-    created: string;
-    last_modified: string;
-    size: number;
-    type?: string;
-    session_id?: string;
-    content?: any;
-    checksum?: string;
-    metadata?: {[key: string]: any};
-}>(null);
 
 // TODO -- WARNING: showToast is only defined locally, but provided/used everywhere. Move to session?
 export interface ShowToastOptions {
@@ -168,7 +154,6 @@ const emit = defineEmits([
 ]);
 
 const connectionStatus = ref('connecting');
-const saveInterval = ref();
 const beakerSession = ref<typeof BeakerSession>();
 const authDialogVisible = ref<boolean>(props.apiKeyPrompt || false);
 const authDialogEntry = ref<string>("");
@@ -176,6 +161,12 @@ const authMessage = ref<string>("");
 const authRetryCell = ref();
 const loginDialogRef = ref();
 const overlayRef = ref<DynamicDialogInstance>();
+
+const { loadSnapshot, startAutosave, stopAutosave } = useNotebookSnapshot({
+    beakerSession,
+    savefile: () => props.savefile,
+    onOpenFile: (content, name, openOptions) => emit('open-file', content, name, openOptions),
+});
 
 const contextSelectionOpen = ref(false);
 
@@ -259,26 +250,20 @@ const connectionFailure = (error: Error) => {
     });
 }
 
-// Wrapper to allow removal from beforeunload event
-const saveSnapshotWrapper = () => {
-    saveSnapshot();
-}
-
 onMounted(async () => {
     const session: Session = beakerSession.value.session;
     await session.sessionReady;  // Ensure content service is up
-    const sessionId = session.sessionId;
 
-    // Connect listener for authentication message
+    // Actions to perform only after session is connected.
     session.session.ready.then(() => {
+        // Connect listener for authentication message
         const sessionContext = toRaw(session.session.session)
         sessionContext.iopubMessage.connect(iopubMessage);
+        // Start periodic autosave
+        startAutosave();
     });
 
     await loadSnapshot();
-
-    saveInterval.value = setInterval(saveSnapshot, 10000);
-    window.addEventListener("beforeunload", saveSnapshotWrapper);
 });
 
 
@@ -305,185 +290,8 @@ const setAgentModel = async (modelConfig = null, rerunLastCommand = false) => {
 }
 
 onUnmounted(() => {
-    clearInterval(saveInterval.value);
-    saveInterval.value = null;
-    window.removeEventListener("beforeunload", saveSnapshotWrapper);
+    stopAutosave();
 });
-
-const saveSnapshot = async (ignoreSession: boolean = false) => {
-    const session: Session = beakerSession.value?.session;
-    const sessionId = session?.sessionId ;
-
-    const notebookData: {[key: string]: any} = {
-        ...(notebookInfo.value || {}),
-    };
-    if (notebookData.session_id && sessionId && notebookData.session_id !== sessionId) {
-        console.warn(`saveSnapshot: session id mismatch (expected ${notebookData.session_id}, got ${sessionId}); skipping save.`);
-        return;
-    }
-    notebookData.session_id = sessionId;
-
-    // Only save state if there is state to save
-    if (session.notebook) {
-        if (!ignoreSession) {
-            notebookData.content = session.toIPynb();
-        }
-
-        const notebookChecksum: string = hashSum(notebookData.content);
-        const notebookComponent = beakerSession.value.notebookComponent;
-
-        if (notebookChecksum === notebookData.checksum) {
-            // No changes since last save
-            return;
-        }
-        else {
-            notebookData.checksum = notebookChecksum;
-        }
-
-        if (notebookComponent) {
-            notebookData.selectedCell = notebookComponent.selectedCellId
-        }
-
-        if (!notebookData.filename && (props.savefile && typeof props.savefile === "string")) {
-            notebookData.filename = props.savefile;
-        }
-
-        if (notebookData.selectedCell) {
-            // Store selected cell in notebook metadata before saving
-            notebookData.content.metadata = notebookData.content.metadata || {};
-            notebookData.content.metadata.selected_cell = notebookData.selectedCell;
-        }
-
-        if (notebookInfo.value?.type === "browserStorage" && notebookData.id) {
-            const localRecordString = JSON.stringify(notebookData);
-            window.localStorage.setItem(notebookData.id, localRecordString);
-            notebookInfo.value = {
-                ...notebookInfo.value,
-                checksum: notebookChecksum,
-            };
-        }
-        else {
-            const notebookId = notebookInfo.value?.id || "";
-            const saveRequest = await fetch(`/beaker/notebook/${notebookId}?session=${session.sessionId}`, {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify(notebookData),
-            });
-            if (saveRequest.ok) {
-                const response = await saveRequest.json();
-                notebookInfo.value = {
-                    ...notebookInfo.value,
-                    metadata: response,
-                    checksum: notebookChecksum
-                }
-            }
-        }
-    }
-};
-
-const loadSnapshot = async () => {
-    const session: Session = beakerSession.value.session;
-    await session.sessionReady;  // Ensure content service is up
-    const sessionId = session.sessionId;
-
-    try {
-        const notebookInfoResponse = await fetch(`/beaker/notebook/?session=${session.sessionId}`);
-        if (notebookInfoResponse.ok) {
-                const response = await notebookInfoResponse.json();
-                const content = response.content;
-                const metadata = {
-                    ...response,
-                    content: undefined,
-                };
-                const checksum = hashSum(content)
-                notebookInfo.value = {
-                    ...notebookInfo.value,
-                    content,
-                    metadata,
-                    checksum,
-                };
-
-        }
-    }
-    catch (e) {
-        console.error(e);
-        notebookInfo.value = {
-            id: sessionId,
-            name: sessionId,
-            created: "",
-            last_modified: "",
-            size: 0,
-            session_id: sessionId,
-        };
-    }
-
-    const notebookData: {[key: string]: any} = {
-        ...(notebookInfo.value || {}),
-    };
-
-    if (notebookInfo.value?.type === "browserStorage") {
-        // Notebook is stored in browser local storage, load it from there
-        const fullNotebookData = localStorage.getItem("notebookData");
-        const fullData = JSON.parse(fullNotebookData || "null");
-        const localRecord = JSON.parse(window.localStorage.getItem(notebookData.id) || "null");
-
-        const hasLocalRecord = notebookData.id in window.localStorage;
-        const hasLegacyRecord = fullData && sessionId in fullData;
-
-        if (hasLegacyRecord && !hasLocalRecord) {
-            console.log(`Migrating notebook data for session ${sessionId} from full localStorage to per-notebook storage.`);
-            notebookData.content = fullData[sessionId]?.data || undefined;
-            notebookData.selectedCell = fullData[sessionId]?.selectedCell || undefined;
-            if (fullData[sessionId]?.name) {
-                notebookData.name = fullData[sessionId]?.name;
-            }
-
-            notebookInfo.value = {
-                id: notebookData.id,
-                name: notebookData.name,
-                created: notebookData.created,
-                last_modified: notebookData.last_modified,
-                size: notebookData.size,
-                type: "browserStorage",
-                content: notebookData.content,
-                session_id: sessionId,
-            };
-            saveSnapshot(true).then(() => {
-                const fullData = JSON.parse(fullNotebookData || "null");
-                delete fullData[sessionId];
-                window.localStorage.setItem("notebookData", JSON.stringify(fullData));
-            }).then(async () => {
-                await loadSnapshot();
-            });
-            return;
-        }
-        else if (hasLocalRecord && hasLegacyRecord) {
-            // Remove legacy record
-            delete fullData[sessionId];
-            window.localStorage.setItem("notebookData", JSON.stringify(fullData));
-        }
-        else {
-            notebookData.content = localRecord?.content || undefined;
-            notebookData.selectedCell = localRecord?.selectedCell || undefined;
-            if (localRecord?.name) {
-                notebookData.name = localRecord?.name;
-            }
-        }
-    }
-
-    if (notebookData && notebookData.content) {
-        emit('open-file', notebookData.content, notebookData.name, {selectedCell: notebookData.selectedCell});
-    }
-
-    if (notebookData.selectedCell !== undefined) {
-        nextTick(() => {
-            beakerSession.value.notebookComponent?.selectCell(notebookData.selectedCell);
-        });
-    }
-    return notebookData;
-};
 
 const providerConfig = () => {
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
   "click~=8.1",
   "python-dotenv~=1.0",
   "hatch",
+  "platformdirs",
   "toml",
   "dill",
   "pandas",

--- a/src/beaker_notebook/__init__.py
+++ b/src/beaker_notebook/__init__.py
@@ -79,7 +79,6 @@ redirect_map: ImportRedirectMap = {
     },
     'beaker_kernel.service.storage.notebook': {
         'BaseNotebookManager': 'beaker_kernel.services.storage.notebook',
-        'BrowserLocalDataNotebookManager': 'beaker_kernel.services.storage.notebook',
         'FileNotebookManager': 'beaker_kernel.services.storage.notebook',
         'NotebookInfo': 'beaker_kernel.services.storage.notebook',
         'with_hidden_files': 'beaker_kernel.services.storage.notebook',
@@ -162,7 +161,6 @@ redirect_map: ImportRedirectMap = {
     },
     'beaker_notebook.service.storage.notebook': {
         'BaseNotebookManager': 'beaker_notebook.services.storage.notebook',
-        'BrowserLocalDataNotebookManager': 'beaker_notebook.services.storage.notebook',
         'FileNotebookManager': 'beaker_notebook.services.storage.notebook',
         'NotebookInfo': 'beaker_notebook.services.storage.notebook',
         'with_hidden_files': 'beaker_notebook.services.storage.notebook',

--- a/src/beaker_notebook/app/api/notebook.py
+++ b/src/beaker_notebook/app/api/notebook.py
@@ -48,37 +48,13 @@ class NotebookHandler(JupyterHandler):
 
     async def get(self, notebook_id=None):
         notebook_id = notebook_id or None
-        session_id = self.get_query_argument("session", None)
         try:
-            notebook = await self.notebook_manager.get_notebook(notebook_id, session_id)
+            notebook = await self.notebook_manager.get_notebook(notebook_id)
         except FileNotFoundError:
             notebook = None
         if notebook is None:
             raise tornado.web.HTTPError(404, "Notebook not found")
         self.write(notebook)
-        # if notebook_id:
-        #     try:
-        #         notebook = await self.notebook_manager.get_notebook(notebook_id)
-        #         self.write(notebook)
-        #         return
-        #     except FileNotFoundError:
-        #         raise tornado.web.HTTPError(404, f"Notebook {notebook_id} not found")
-
-        # notebooks = await self.notebook_manager.list_notebooks()
-
-        # If only a single notebook with ID "*", return it directly to allow browser to use alternative storage
-        # if len(notebooks) == 1 and notebooks[0].id == "*":
-        #     notebooks[0].session_id = session_id
-            # return self.write(notebooks[0])
-
-        # if session_id is not None:
-        #     for nb in notebooks:
-        #         if nb.session_id == session_id:
-        #             notebook = await self.notebook_manager.get_notebook(nb.id)
-        #             self.write(notebook)
-        #     raise tornado.web.HTTPError(404, f"No notebook found for session {session_id}")
-        # else:
-        #     self.write(notebooks)
 
     async def post(self, notebook_id=None):
         notebook_id = notebook_id or None
@@ -97,14 +73,6 @@ class NotebookHandler(JupyterHandler):
         )
         self.write(notebook)
 
-    # async def patch(self, notebook_id=None):
-    #     body = tornado.escape.json_decode(self.request.body)
-    #     self.write({})
-    #
-    # async def put(self, notebook_id=None):
-    #     body = tornado.escape.json_decode(self.request.body)
-    #     self.write({})
-
     async def delete(self, notebook_id=None):
         if not notebook_id:
             raise tornado.web.HTTPError(400, "No notebook ID provided for deletion")
@@ -113,6 +81,82 @@ class NotebookHandler(JupyterHandler):
         # self.finish()
 
 
+class SnapshotHandler(JupyterHandler):
+    """
+    Handler for session based notebook snapshots.
+    """
+
+    def set_default_headers(self):
+        self.set_header("Content-Type", "application/json")
+
+    def write(self, chunk):
+        if is_dataclass(chunk):
+            chunk = asdict(chunk)
+        elif isinstance(chunk, list):
+            chunk = [asdict(item) if is_dataclass(item) else item for item in chunk]
+        if isinstance(chunk, (dict, list)):
+            chunk = json.dumps(chunk, default=json_default)
+        return super().write(chunk)
+
+    @property
+    def notebook_manager(self) -> "BaseNotebookManager":
+        notebook_manager = getattr(self.serverapp, "notebook_manager", None)
+        if notebook_manager is None:
+            raise tornado.web.HTTPError(404, "Notebook manager not found")
+        return notebook_manager
+
+    def _safe_session_id(self, session_id: str) -> str:
+        """Ensure the session id is a single, traversal-free path component.
+
+        The session id is taken straight from the URL and used to build the
+        snapshot filename, so reject anything that could escape the snapshot
+        directory before it reaches the storage layer.
+        """
+        if not session_id:
+            raise tornado.web.HTTPError(400, "No session ID provided")
+        if session_id in (".", "..") or "/" in session_id or "\\" in session_id or "\x00" in session_id:
+            raise tornado.web.HTTPError(400, "Invalid session ID")
+        return session_id
+
+    async def head(self, session_id=None):
+        try:
+            snapshots = await self.notebook_manager.list_snapshots()
+            self.write(snapshots)
+        except Exception:
+            self.write({})
+
+    async def get(self, session_id):
+        session_id = self._safe_session_id(session_id)
+        try:
+            notebook = await self.notebook_manager.get_snapshot(session_id)
+        except FileNotFoundError:
+            notebook = None
+        if notebook is None:
+            raise tornado.web.HTTPError(404, "Notebook not found")
+        self.write(notebook)
+
+    async def post(self, session_id):
+        session_id = self._safe_session_id(session_id)
+        name = self.get_query_argument("name", None)
+        body = tornado.escape.json_decode(self.request.body)
+        content: "typing.Optional[NotebookContent]" = body.get("content", None)
+        if content is None:
+            raise tornado.web.HTTPError(400, "No notebook content provided in request body")
+
+        notebook: "NotebookInfo" = await self.notebook_manager.save_snapshot(
+            session_id=session_id,
+            content=content,
+            name=name,
+        )
+        self.write(notebook)
+
+    async def delete(self, session_id):
+        session_id = self._safe_session_id(session_id)
+        await self.notebook_manager.delete_snapshot(session_id)
+        self.set_status(204)
+
+
 handlers = [
+    (r"/notebook/snapshot/?(?P<session_id>.*)/?$", SnapshotHandler),
     (r"/notebook/?(?P<notebook_id>.*)/?$", NotebookHandler),
 ]

--- a/src/beaker_notebook/app/notebook_app.py
+++ b/src/beaker_notebook/app/notebook_app.py
@@ -1,5 +1,11 @@
+from pathlib import Path
+
 from beaker_notebook.app.base import BaseBeakerApp
 from beaker_notebook.services.auth.notebook import NotebookAuthorizer, NotebookIdentityProvider
+from beaker_notebook.services.storage import BEAKER_LOCAL_DATA_PATH
+
+
+SNAPSHOT_PATH = Path(BEAKER_LOCAL_DATA_PATH / "notebooks").resolve()
 
 
 class BeakerNotebookApp(BaseBeakerApp):
@@ -7,6 +13,9 @@ class BeakerNotebookApp(BaseBeakerApp):
     defaults = {
         "authorizer_class": NotebookAuthorizer,
         "identity_provider_class": NotebookIdentityProvider,
+        "FileNotebookManager": {
+            "snapshot_path": str(SNAPSHOT_PATH)
+        }
     }
 
 if __name__ == "__main__":

--- a/src/beaker_notebook/services/storage/__init__.py
+++ b/src/beaker_notebook/services/storage/__init__.py
@@ -1,0 +1,72 @@
+import asyncio
+import os
+import pathlib
+import platformdirs
+
+from jupyter_core.utils import ensure_async
+from jupyter_server.services.contents.manager import ContentsManager
+
+
+BEAKER_LOCAL_DATA_PATH = platformdirs.user_data_path("beaker")
+
+
+def with_hidden_files(func):
+    """Decorator to temporarily enable hidden files during a method call."""
+    async def wrapper(self, *args, **kwargs):
+        orig_allow_hidden = self.contents_manager.allow_hidden
+        self.contents_manager.allow_hidden = True
+        try:
+            result = await ensure_async(func(self, *args, **kwargs))
+        finally:
+            self.contents_manager.allow_hidden = orig_allow_hidden
+        return result
+    return wrapper
+
+
+temp_root_lock = asyncio.Lock()
+class with_temp_root():
+    def __init__(self, contents_manager: ContentsManager, root: os.PathLike):
+        self.cm = contents_manager
+        self.orig_root = None
+        self.temp_root = root
+
+    async def __aenter__(self):
+        # Setting trait values directly to avoid calling root_dir's validator which doesn't
+        # like what we're doing here.
+        await temp_root_lock.acquire()
+        try:
+            self.orig_root = self.cm.root_dir
+            self.cm._trait_values["root_dir"] = self.temp_root
+        except BaseException:
+            temp_root_lock.release()
+            raise
+
+    async def __aexit__(self, exc_type, exc, tb):
+        try:
+            self.cm._trait_values["root_dir"] = self.orig_root
+        finally:
+            temp_root_lock.release()
+
+
+async def create_directory_tree(contents_manager, path) -> None:
+    if await ensure_async(contents_manager.dir_exists(str(path))):
+        return None
+
+    dirs_to_create = [path, ]
+    parents = pathlib.Path(path).parents
+    for parent in parents:
+        if await ensure_async(contents_manager.dir_exists(str(parent))):
+            break
+        else:
+            dirs_to_create.append(parent)
+    for dir in reversed(dirs_to_create):
+        try:
+            await ensure_async(contents_manager.new(
+                model={
+                    "type": "directory",
+                },
+                path=str(dir)
+            ))
+        except ValueError:
+            if not await ensure_async(contents_manager.dir_exists(str(dir))):
+                raise   # the mkdir didn't land — this isn't the benign assertion

--- a/src/beaker_notebook/services/storage/base.py
+++ b/src/beaker_notebook/services/storage/base.py
@@ -1,28 +1,14 @@
 import json
 import os
 import os.path
-from dataclasses import dataclass
-from typing import Any
-
-import traitlets
+from pathlib import Path
 
 from jupyter_server.base.handlers import AuthenticatedFileHandler
 from jupyter_server.services.contents.manager import ContentsManager
 from jupyter_server.services.contents.largefilemanager import AsyncLargeFileManager
-from beaker_notebook.services.auth import current_user, BeakerUser, BeakerAuthorizer, BeakerIdentityProvider
 
-
-def with_hidden_files(func):
-    """Decorator to temporarily enable hidden files during a method call."""
-    async def wrapper(self, *args, **kwargs):
-        orig_allow_hidden = self.contents_manager.allow_hidden
-        self.contents_manager.allow_hidden = True
-        try:
-            result = await func(self, *args, **kwargs)
-        finally:
-            self.contents_manager.allow_hidden = orig_allow_hidden
-        return result
-    return wrapper
+from beaker_notebook.services.auth import current_user, BeakerUser
+from beaker_notebook.services.storage import BEAKER_LOCAL_DATA_PATH, with_hidden_files, with_temp_root
 
 
 class BaseBeakerContentsManager(ContentsManager):
@@ -63,6 +49,14 @@ class BeakerLocalContentsManager(AsyncLargeFileManager, BaseBeakerContentsManage
         str
             Absolute path within user's home directory
         """
+
+        # Allow local contents manager to access files within the user's data_path as well.
+        # Resolve first: is_relative_to() is purely lexical, so without normalizing away
+        # ".." segments a crafted path could pass this check and still escape the data path.
+        abs_path = (Path("/") / path).resolve()
+        if abs_path.is_relative_to(BEAKER_LOCAL_DATA_PATH.resolve()):
+            return str(abs_path)
+
         user: BeakerUser = current_user.get()
         if isinstance(user, BeakerUser):
             userdir_path = os.path.join(self.parent.virtual_home_root, user.home_dir)

--- a/src/beaker_notebook/services/storage/notebook.py
+++ b/src/beaker_notebook/services/storage/notebook.py
@@ -1,5 +1,5 @@
 import os.path
-import uuid
+import pathlib
 from dataclasses import dataclass
 from typing import Any, Optional, TypeAlias, Literal
 
@@ -9,20 +9,9 @@ from traitlets.config import Configurable
 from jupyter_core.utils import ensure_async
 from jupyter_server.services.contents.manager import ContentsManager
 from jupyter_server.services.contents.filemanager import AsyncFileContentsManager
-from beaker_notebook.services.auth import BeakerUser
 
+from beaker_notebook.services.storage import create_directory_tree, with_hidden_files, with_temp_root
 
-def with_hidden_files(func):
-    """Decorator to temporarily enable hidden files during a method call."""
-    async def wrapper(self, *args, **kwargs):
-        orig_allow_hidden = self.contents_manager.allow_hidden
-        self.contents_manager.allow_hidden = True
-        try:
-            result = await ensure_async(func(self, *args, **kwargs))
-        finally:
-            self.contents_manager.allow_hidden = orig_allow_hidden
-        return result
-    return wrapper
 
 
 NotebookContent: TypeAlias = dict[str, Any]
@@ -41,20 +30,60 @@ class NotebookInfo:
 
 
 class BaseNotebookManager(Configurable):
+
+    notebook_path = traitlets.Unicode(
+        ".notebooks",
+        help="Base path for storing notebooks when performing a user-initiated save.",
+        config=True,
+    )
+    snapshot_path = traitlets.Unicode(
+        help="Base path for storing snapshots, automatically saved versions of the notebook.",
+        config=True,
+    )
+
+    @traitlets.default("snapshot_path")
+    def _default_snapshot_path(self):
+        """Default to save snapshots in same directory as user-saved notebooks if not defined on the server application."""
+        return os.path.join(self.notebook_path, ".snapshots")
+
+    async def _list_notebooks(self, path) -> list[NotebookInfo]:
+        raise NotImplementedError()
+
+    async def _get_notebook(self, path: os.PathLike, filename: str) -> Optional[NotebookInfo]:
+        raise NotImplementedError()
+
+    async def _save_notebook(self, path: os.PathLike, filename: str, content: NotebookContent, **kwargs):
+        raise NotImplementedError()
+
+    async def _delete_notebook(self, path: os.PathLike, filename: str) -> None:
+        raise NotImplementedError()
+
     async def get_notebook_info(self, notebook_id: str) -> NotebookInfo:
         raise NotImplementedError()
 
     async def list_notebooks(self) -> list[NotebookInfo]:
-        raise NotImplementedError()
+        return await self._list_notebooks(path=self.notebook_path)
 
-    async def get_notebook(self, notebook_id: Optional[str] = None, session_id: Optional[str] = None) -> Optional[NotebookInfo]:
-        raise NotImplementedError()
+    async def get_notebook(self, notebook_id: str) -> Optional[NotebookInfo]:
+        return await self._get_notebook(path=self.notebook_path, filename=notebook_id)
 
-    async def save_notebook(self, notebook_id: str, content: NotebookContent) -> NotebookInfo:
-        raise NotImplementedError()
+    async def save_notebook(self, notebook_id: str, content: NotebookContent, **kwargs) -> NotebookInfo:
+        return await self._save_notebook(path=self.notebook_path, filename=notebook_id, content=content, **kwargs)
 
     async def delete_notebook(self, notebook_id: str) -> None:
-        raise NotImplementedError()
+        return await self._delete_notebook(path=self.notebook_path, filename=notebook_id)
+
+    async def list_snapshots(self) -> list[NotebookInfo]:
+        return await self._list_notebooks(path=self.snapshot_path)
+
+    async def get_snapshot(self, session_id: str) -> Optional[NotebookInfo]:
+        return await self._get_notebook(path=self.snapshot_path, filename=f"{session_id}.ipynb")
+
+    async def save_snapshot(self,  session_id: str, content: NotebookContent, **kwargs) -> NotebookInfo:
+        return await self._save_notebook(path=self.snapshot_path, filename=f"{session_id}.ipynb", content=content, session=session_id, **kwargs)
+
+    async def delete_snapshot(self, session_id: str) -> None:
+        return await self._delete_notebook(path=self.snapshot_path, filename=f"{session_id}.ipynb")
 
 
 class FileNotebookManager(BaseNotebookManager):
@@ -74,11 +103,6 @@ class FileNotebookManager(BaseNotebookManager):
         help="Contents manager used by the NotebookManager",
         config=True,
     )
-    notebook_path = traitlets.Unicode(
-        ".notebooks/",
-        help="Base path for storing notebooks, relative to contents manager root",
-        config=True,
-    )
 
     @traitlets.default("contents_manager")
     def _default_contents_manager(self):
@@ -88,34 +112,6 @@ class FileNotebookManager(BaseNotebookManager):
             return self.parent.contents_manager
         else:
             return AsyncFileContentsManager(parent=self.parent)
-
-    @property
-    def _notebook_path(self) -> str:
-        try:
-            path = self.notebook_path.format(notebook_id="")
-        except KeyError:
-            path = self.notebook_path
-        return path
-
-
-    @with_hidden_files
-    async def _find_notebook(self, notebook_id: str) -> str:
-        """Find the file path for a given notebook session ID.
-
-        Parameters
-        ----------
-        notebook_id : str
-            The session ID of the notebook.
-
-        Returns
-        -------
-        str
-            The file path of the notebook.
-        """
-        path = os.path.join(self.notebook_path, notebook_id)
-        if not await ensure_async(self.contents_manager.file_exists(path)):
-            raise FileNotFoundError(f"Notebook with session ID {notebook_id} not found")
-        return path
 
     async def get_notebook_info(self, notebook_id: str) -> NotebookInfo:
         """Retrieve notebook metadata for a given session ID.
@@ -130,22 +126,22 @@ class FileNotebookManager(BaseNotebookManager):
         NotebookInfo
             Metadata about the notebook.
         """
-
-        path = await ensure_async(self._find_notebook(notebook_id))
-        notebook = await ensure_async(self.contents_manager.get(
-            path,
-            content=False
-        ))
-        return NotebookInfo(
-            id=notebook['name'],
-            name=notebook['name'],
-            created=notebook.get('created', None),
-            last_modified=notebook.get('last_modified', None),
-            size=notebook.get('size', None),
-        )
+        async with with_temp_root(contents_manager= self.contents_manager, root=self.notebook_path):
+            path = os.path.join(self.notebook_path, notebook_id)
+            notebook = await ensure_async(self.contents_manager.get(
+                path,
+                content=False
+            ))
+            return NotebookInfo(
+                id=notebook['name'],
+                name=notebook['name'],
+                created=notebook.get('created', None),
+                last_modified=notebook.get('last_modified', None),
+                size=notebook.get('size', None),
+            )
 
     @with_hidden_files
-    async def list_notebooks(self) -> list[NotebookInfo]:
+    async def _list_notebooks(self, path) -> list[NotebookInfo]:
         """
         List all notebooks managed by this NotebookManager.
 
@@ -154,99 +150,73 @@ class FileNotebookManager(BaseNotebookManager):
         list[NotebookInfo]
             A list of metadata for all notebooks.
         """
-
-        path = self._notebook_path
-        if await ensure_async(self.contents_manager.dir_exists(path)):
-            files = await ensure_async(self.contents_manager.get(path, type="directory", content=True))
-        else:
-            files = {
-                "content": []
-            }
-        return sorted(
-            [
-                NotebookInfo(
-                    id=file['name'],
-                    name=file['name'],
-                    created=file.get('created', None),
-                    last_modified=file.get('last_modified', None),
-                    size=file.get('size', None),
-                    session_id=file.get('session_id', None),
-                )
-                for file
-                in files.get("content", []) if file['type'] == 'notebook'
-            ],
-            key=lambda notebook: notebook.last_modified, reverse=True
-        )
+        async with with_temp_root(contents_manager= self.contents_manager, root=path):
+            if await ensure_async(self.contents_manager.dir_exists(path)):
+                files = await ensure_async(self.contents_manager.get(path, type="directory", content=True))
+            else:
+                files = {
+                    "content": []
+                }
+            return sorted(
+                [
+                    NotebookInfo(
+                        id=file['name'],
+                        name=file['name'],
+                        created=file.get('created', None),
+                        last_modified=file.get('last_modified', None),
+                        size=file.get('size', None),
+                        session_id=file.get('session_id', None),
+                    )
+                    for file
+                    in files.get("content", []) if file['type'] == 'notebook'
+                ],
+                key=lambda notebook: notebook.last_modified, reverse=True
+            )
 
     @with_hidden_files
-    async def get_notebook(
+    async def _get_notebook(
         self,
-        notebook_id: Optional[str] = None,
-        session_id: Optional[str] = None,
+        path: os.PathLike,
+        filename: str,
     ) -> Optional[NotebookInfo]:
         """
         Retrieve a notebook's content and metadata by its session ID.
 
         Parameters
         ----------
-        notebook_id : str
-            The unique ID of the notebook.
+        path : os.PathLike
+            The location relative to content root or an absolute path that is a subdirectory of
+            beaker_notebook.services.storage.BEAKER_LOCAL_DATA_PATH.
 
         Returns
         -------
         NotebookInfo
             The notebook's metadata and content.
         """
-        match notebook_id, session_id:
-            case None, None:
-                raise ValueError("Either notebook_id or session_id must be provided")
-            case str(), _:
-                try:
-                    path = await ensure_async(self._find_notebook(notebook_id))
-                except KeyError:
-                    path = self.notebook_path
-                file = await ensure_async(self.contents_manager.get(path, content=True))
-                notebook = NotebookInfo(
-                    id=file['name'],
-                    name=file['name'],
-                    created=file.get('created', None),
-                    last_modified=file.get('last_modified', None),
-                    size=file.get('size', None),
-                    content=file.get('content', None),
-                    session_id=file.get('session_id', None),
-                )
-                return notebook
-            case _, str():
-                # Search for notebook with matching session ID
-                notebooks = await ensure_async(self.list_notebooks())
-                notebook_meta = next(
-                    (nb for nb in notebooks if nb.session_id == session_id),
-                    None,
-                )
-                if notebook_meta is None:
-                    raise FileNotFoundError(f"No notebook found for session ID {session_id}")
-                path = await ensure_async(self._find_notebook(notebook_meta.id))
-                file = await ensure_async(self.contents_manager.get(path, content=True))
-                notebook = NotebookInfo(
-                    id=file['name'],
-                    name=file['name'],
-                    created=file.get('created', None),
-                    last_modified=file.get('last_modified', None),
-                    size=file.get('size', None),
-                    content=file.get('content', None),
-                    session_id=file.get('session_id', None),
-                )
-                return notebook
-            case _:
-                raise ValueError("Invalid arguments provided")
+        async with with_temp_root(contents_manager= self.contents_manager, root=path):
+            full_path = os.path.join(path, filename)
+            if not await ensure_async(self.contents_manager.file_exists(full_path)):
+                raise FileNotFoundError(f"Notebook {filename} not found")
+            file = await ensure_async(self.contents_manager.get(full_path, content=True))
+            notebook = NotebookInfo(
+                id=file['name'],
+                name=file['name'],
+                created=file.get('created', None),
+                last_modified=file.get('last_modified', None),
+                size=file.get('size', None),
+                content=file.get('content', None),
+                session_id=file.get('session_id', None),
+            )
+            return notebook
 
     @with_hidden_files
-    async def save_notebook(
+    async def _save_notebook(
         self,
+        path: os.PathLike,
+        filename: str,
         content: NotebookContent,
-        notebook_id: Optional[str] = None,
         session: Optional[str] = None,
-        name: Optional[str] = None,
+        **kwargs,
     ) -> NotebookInfo:
         """
         Save a notebook's content by its session ID.
@@ -261,101 +231,39 @@ class FileNotebookManager(BaseNotebookManager):
         Returns
         -------
         NotebookInfo
-            The saved notebook's metadata."""
-        if session is None:
-            session = str(uuid.uuid4())
-        if notebook_id is None:
-            notebook_id = f"{session}.ipynb"
-        if name is None:
-            name = notebook_id
-        content.setdefault("metadata", {})
-        content["metadata"].setdefault("beaker", {})
-        content["metadata"]["beaker"]["session_id"] = session
-        path = os.path.join(self.notebook_path, notebook_id)
-        model = {
-            "type": "notebook",
-            "content": content,
-            "format": "json",
-            "session_id": session,
-        }
-        if not await ensure_async(self.contents_manager.dir_exists(self.notebook_path)):
-            await ensure_async(self.contents_manager.new(
-                model={
-                    "type": "directory",
-                },
-                path=self.notebook_path
-            ))
-        if await ensure_async(self.contents_manager.file_exists(path)):
-            return await ensure_async(self.contents_manager.save(model=model, path=path))
-        else:
-            return await ensure_async(self.contents_manager.new(model=model, path=path))
+            The saved notebook's metadata.
+        """
+        async with with_temp_root(contents_manager= self.contents_manager, root=path):
+            content.setdefault("metadata", {})
+            content["metadata"].setdefault("beaker", {})
+            if session:
+                content["metadata"]["beaker"]["session_id"] = session
 
-
+            full_path = os.path.join(path, filename)
+            model = {
+                "type": "notebook",
+                "content": content,
+                "format": "json",
+                "session_id": session,
+            }
+            await create_directory_tree(self.contents_manager, path)
+            if await ensure_async(self.contents_manager.file_exists(full_path)):
+                return await ensure_async(self.contents_manager.save(model=model, path=full_path))
+            else:
+                return await ensure_async(self.contents_manager.new(model=model, path=full_path))
 
     @with_hidden_files
-    async def delete_notebook(self, notebook_id: str) -> None:
+    async def _delete_notebook(self, path: os.PathLike, filename: str) -> None:
         """
         Delete a notebook by its ID.
 
         Parameters
         ----------
-        notebook_id : str
-            The ID of the notebook to delete.
+        filename : str
+            The name of the notebook file to delete.
         """
-        return await ensure_async(self.contents_manager.delete(
-            os.path.join(self.notebook_path, notebook_id)
-        ))
+        async with with_temp_root(contents_manager= self.contents_manager, root=path):
+            return await ensure_async(self.contents_manager.delete(
+                os.path.join(path, filename)
+            ))
 
-
-class BrowserLocalDataNotebookManager(BaseNotebookManager):
-    """
-    Dummy implementation of notebook manager that stores notebooks in the browser's local storage.
-    """
-
-    async def get_notebook_info(self, notebook_id: str) -> NotebookInfo:
-        record_id = f"browser-{notebook_id}"
-        return NotebookInfo(
-            id=record_id,
-            name=notebook_id,
-            type="browserStorage",
-            created="",
-            last_modified="",
-            size=0,
-        )
-
-    async def list_notebooks(self) -> list[NotebookInfo]:
-        return [
-            NotebookInfo(
-                id="*",
-                name="*",
-                type="browserStorage",
-                created="",
-                last_modified="",
-                size=0,
-            )
-        ]
-
-    async def get_notebook(
-        self,
-        notebook_id: Optional[str] = None,
-        session_id: Optional[str] = None,
-    ) -> Optional[NotebookInfo]:
-        if notebook_id:
-            record_id = f"browser-notebook:{notebook_id}"
-        elif session_id:
-            record_id = f"browser-session:{session_id}"
-        return NotebookInfo(
-            id=record_id,
-            name=notebook_id,
-            type="browserStorage",
-            created="",
-            last_modified="",
-            size=0,
-            session_id=session_id,
-        )
-
-    async def save_notebook(self, notebook_id: str, content: NotebookContent) -> NotebookInfo:
-        raise NotImplementedError("Browser local data notebooks cannot be saved to the server")
-
-    async def delete_notebook(self, notebook_id: str) -> None:
-        raise NotImplementedError("Browser local data notebooks cannot be deleted from the server")

--- a/tests/test_notebook_snapshot_storage.py
+++ b/tests/test_notebook_snapshot_storage.py
@@ -1,0 +1,226 @@
+"""Regression tests for Beaker server-side notebook snapshot storage.
+
+These capture failure modes worked out while moving notebook snapshots off
+browser ``localStorage`` and onto the server notebook storage API:
+
+* Session ids arrive verbatim from the request URL and are interpolated into a
+  snapshot filename, so ``SnapshotHandler`` must reject anything that could
+  traverse out of the snapshot directory.
+* ``BeakerLocalContentsManager._get_os_path`` must ``resolve()`` before its
+  ``is_relative_to`` containment check. ``is_relative_to`` is purely lexical, so
+  without normalizing ``..`` away a crafted absolute path can pass the check and
+  still escape ``BEAKER_LOCAL_DATA_PATH``.
+* ``with_temp_root`` swaps the contents manager's ``root_dir`` (bypassing its
+  validator), so it must restore the original and must *never* leak its global
+  lock -- a leaked lock hangs every subsequent snapshot operation in the process.
+* ``create_directory_tree`` must create directories more than one level deep
+  (which ``ContentsManager.new`` will not), and must swallow *only* the benign
+  out-of-root ``is_hidden`` assertion, re-raising everything else.
+* ``save``/``get``/``list``/``delete`` snapshot round-trips, including the
+  selected-cell value the front end stashes in notebook metadata; and
+  ``delete_snapshot`` takes only a session id.
+"""
+
+import asyncio
+import os
+from pathlib import Path
+
+import pytest
+import tornado.web
+from jupyter_server.services.contents.filemanager import AsyncFileContentsManager
+
+import beaker_notebook.services.storage as storage_pkg
+import beaker_notebook.services.storage.base as storage_base
+from beaker_notebook.app.api.notebook import SnapshotHandler
+from beaker_notebook.services.storage import (
+    create_directory_tree,
+    temp_root_lock,
+    with_temp_root,
+)
+from beaker_notebook.services.storage.base import BeakerLocalContentsManager
+from beaker_notebook.services.storage.notebook import FileNotebookManager
+
+
+def _notebook(selected_cell=None):
+    """A minimal valid ipynb dict, optionally carrying a selected-cell marker."""
+    metadata = {}
+    if selected_cell is not None:
+        metadata["selected_cell"] = selected_cell
+    return {
+        "cells": [],
+        "metadata": metadata,
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+
+
+@pytest.fixture
+def data_path(tmp_path, monkeypatch):
+    """Repoint ``BEAKER_LOCAL_DATA_PATH`` at a temp dir.
+
+    Patched in both the package and ``base`` (where ``_get_os_path`` closes over
+    the imported name) so the data-path branch resolves to the sandbox.
+    """
+    monkeypatch.setattr(storage_pkg, "BEAKER_LOCAL_DATA_PATH", tmp_path)
+    monkeypatch.setattr(storage_base, "BEAKER_LOCAL_DATA_PATH", tmp_path)
+    return tmp_path
+
+
+@pytest.fixture
+def plain_cm(tmp_path):
+    """A vanilla contents manager rooted at the temp dir."""
+    return AsyncFileContentsManager(root_dir=str(tmp_path))
+
+
+@pytest.fixture
+def local_cm(data_path):
+    """A Beaker contents manager rooted at the (sandboxed) data dir."""
+    return BeakerLocalContentsManager(root_dir=str(data_path))
+
+
+@pytest.fixture
+def manager(data_path, local_cm):
+    """A FileNotebookManager whose snapshot dir is two levels below the data
+    root and does not yet exist, so a save must build the tree."""
+    return FileNotebookManager(
+        contents_manager=local_cm,
+        snapshot_path=str(data_path / "notebooks" / ".snapshots"),
+        notebook_path=str(data_path / ".notebook"),
+    )
+
+
+class TestSafeSessionId:
+    """SnapshotHandler must reject session ids that aren't a single, safe path
+    component before they reach the storage layer."""
+
+    @staticmethod
+    def _handler():
+        # _safe_session_id only touches its argument, so a bare instance built
+        # without tornado's RequestHandler.__init__ is sufficient to exercise it.
+        return SnapshotHandler.__new__(SnapshotHandler)
+
+    def test_accepts_plain_session_id(self):
+        assert self._handler()._safe_session_id("abc-123") == "abc-123"
+
+    @pytest.mark.parametrize(
+        "bad",
+        ["", ".", "..", "a/b", "a\\b", "x\x00y", "../../etc/passwd"],
+    )
+    def test_rejects_traversal_and_separators(self, bad):
+        with pytest.raises(tornado.web.HTTPError) as excinfo:
+            self._handler()._safe_session_id(bad)
+        assert excinfo.value.status_code == 400
+
+
+class TestGetOsPathContainment:
+    """_get_os_path must resolve before deciding a path is inside the data dir."""
+
+    def test_path_within_data_dir_is_returned_as_is(self, local_cm, data_path):
+        target = str(data_path / "notebooks" / ".snapshots" / "s.ipynb")
+        assert local_cm._get_os_path(target) == target
+
+    def test_dotdot_traversal_cannot_escape_data_dir(self, local_cm, data_path):
+        # Lexically this path is "under" the data dir, so the pre-resolve()
+        # containment check would have returned it verbatim and let the OS
+        # resolve the ".." out to /etc/passwd.
+        escaping = os.path.join(str(data_path), "notebooks", "../../../../etc/passwd")
+        resolved = os.path.realpath(local_cm._get_os_path(escaping))
+        assert resolved != "/etc/passwd"
+        assert Path(resolved).is_relative_to(os.path.realpath(str(data_path)))
+
+
+class TestWithTempRoot:
+    """The root_dir swap must be reversible, validator-free, and lock-safe."""
+
+    async def test_bypasses_validator_restores_root_and_releases_lock(self, plain_cm, tmp_path):
+        original = plain_cm.root_dir
+        missing = str(tmp_path / "does" / "not" / "exist")
+        async with with_temp_root(contents_manager=plain_cm, root=missing):
+            # The root_dir validator would reject a non-existent dir; the swap
+            # writes the trait store directly to get around it.
+            assert str(plain_cm.root_dir) == missing
+            assert temp_root_lock.locked()
+        assert plain_cm.root_dir == original
+        assert not temp_root_lock.locked()
+
+    async def test_lock_released_and_root_restored_when_body_raises(self, plain_cm, tmp_path):
+        original = plain_cm.root_dir
+        with pytest.raises(RuntimeError):
+            async with with_temp_root(contents_manager=plain_cm, root=str(tmp_path / "x")):
+                raise RuntimeError("boom")
+        # A leaked lock here would deadlock every later snapshot operation.
+        assert not temp_root_lock.locked()
+        assert plain_cm.root_dir == original
+
+    async def test_concurrent_blocks_do_not_corrupt_root_dir(self, plain_cm, tmp_path):
+        original = plain_cm.root_dir
+        observed_own_root = []
+
+        async def worker(name):
+            root = str(tmp_path / name)
+            async with with_temp_root(contents_manager=plain_cm, root=root):
+                # Without the serializing lock, a sibling task could swap
+                # root_dir out from under us across this await point.
+                await asyncio.sleep(0)
+                observed_own_root.append(str(plain_cm.root_dir) == root)
+
+        await asyncio.gather(*(worker(f"r{i}") for i in range(8)))
+        assert observed_own_root and all(observed_own_root)
+        assert plain_cm.root_dir == original
+
+
+class TestCreateDirectoryTree:
+    """ContentsManager.new only creates one level; create_directory_tree fills
+    in the missing parents."""
+
+    async def test_creates_nested_dirs_more_than_one_level_deep(self, plain_cm, tmp_path):
+        await create_directory_tree(plain_cm, "a/b/c")
+        assert (tmp_path / "a" / "b" / "c").is_dir()
+
+    async def test_idempotent_when_tree_already_exists(self, plain_cm, tmp_path):
+        await create_directory_tree(plain_cm, "a/b/c")
+        await create_directory_tree(plain_cm, "a/b/c")  # must not raise
+        assert (tmp_path / "a" / "b" / "c").is_dir()
+
+
+class TestSnapshotLifecycle:
+    """End-to-end behavior of the snapshot CRUD surface."""
+
+    async def test_save_then_get_round_trips_content(self, manager):
+        await manager.save_snapshot(session_id="sess-1", content=_notebook())
+        got = await manager.get_snapshot("sess-1")
+        assert got.content["nbformat"] == 4
+
+    async def test_selected_cell_metadata_round_trips(self, manager):
+        await manager.save_snapshot(
+            session_id="sess-1", content=_notebook(selected_cell="cell-xyz")
+        )
+        got = await manager.get_snapshot("sess-1")
+        assert got.content["metadata"]["selected_cell"] == "cell-xyz"
+
+    async def test_save_builds_missing_nested_snapshot_dir(self, manager, data_path):
+        # Exercises create_directory_tree across the contents-manager root
+        # boundary: building ``notebooks/`` (a parent of the temp root) trips and
+        # swallows the benign is_hidden assertion, then ``.snapshots/`` is created
+        # cleanly.
+        snapshot_dir = data_path / "notebooks" / ".snapshots"
+        assert not snapshot_dir.exists()
+        await manager.save_snapshot(session_id="sess-1", content=_notebook())
+        assert (snapshot_dir / "sess-1.ipynb").is_file()
+
+    async def test_list_snapshots_includes_saved(self, manager):
+        await manager.save_snapshot(session_id="sess-1", content=_notebook())
+        await manager.save_snapshot(session_id="sess-2", content=_notebook())
+        names = {info.name for info in await manager.list_snapshots()}
+        assert {"sess-1.ipynb", "sess-2.ipynb"} <= names
+
+    async def test_delete_snapshot_removes_file(self, manager):
+        # Also pins delete_snapshot's signature: session id only, no content arg.
+        await manager.save_snapshot(session_id="sess-1", content=_notebook())
+        await manager.delete_snapshot("sess-1")
+        with pytest.raises(FileNotFoundError):
+            await manager.get_snapshot("sess-1")
+
+    async def test_get_missing_snapshot_raises_file_not_found(self, manager):
+        with pytest.raises(FileNotFoundError):
+            await manager.get_snapshot("never-saved")


### PR DESCRIPTION
When chat history is serialized alongside full notebook content, the snapshot can easily exceed the browser's LocalStorage quota and saving silently breaks. Moves notebook autosave/restore off browser storage and onto the server notebook storage API, where snapshots are persisted as ordinary .ipynb files.

Backend:
- Add a SnapshotHandler exposing /notebook/snapshot/<session_id> (GET/POST/ DELETE/HEAD) for session-keyed snapshots, separate from user-initiated notebook saves. Session ids come straight from the URL, so reject any value that isn't a single traversal-free path component.
- Restructure BaseNotebookManager around path-based _list/_get/_save/_delete primitives, with notebook_path and snapshot_path traits. Snapshots default to <notebook_path>/.snapshots and are stored as <session_id>.ipynb.
- Store snapshots under platformdirs user data dir (notebooks/) by configuring FileNotebookManager.snapshot_path in BeakerNotebookApp; add platformdirs dep.
- Let BeakerLocalContentsManager serve files under BEAKER_LOCAL_DATA_PATH, resolving paths before the is_relative_to containment check so ".." segments can't escape the data dir.
- Add with_temp_root (validator-bypassing, lock-serialized root_dir swap) and create_directory_tree helpers; consolidate with_hidden_files into the storage package.
- Remove BrowserLocalDataNotebookManager and its import redirects; drop the session_id lookup arg from get_notebook.

Frontend:
- Extract save/load/autosave logic out of BaseInterface.vue into a useNotebookSnapshot composable that talks only to the snapshot API.
- Drop the browserStorage code path and the legacy LocalStorage migration logic.

Add regression tests covering session-id validation, path containment, with_temp_root lock/restore semantics, nested directory creation, and the snapshot save/get/list/delete round-trip (incl. selected-cell metadata).

Resolves #235